### PR TITLE
Add more categories for the IHCC browser

### DIFF
--- a/gecko.owl
+++ b/gecko.owl
@@ -10,7 +10,7 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:terms="http://purl.org/dc/terms/">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/gecko.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/gecko/2020-07-29/gecko.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/gecko/2020-08-20/gecko.owl"/>
         <dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An ontology to represent genomics cohort attributes.</dc:description>
         <dc:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Genomics Cohorts Knowledge Ontology</dc:title>
         <terms:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
@@ -744,14 +744,24 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GECKO_0000091 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GECKO_0000091">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000115"/>
+        <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">questionnaire/survey data</obo:GECKO_9000000>
+        <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-pharmacological interventions</obo:GECKO_9000001>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-pharmacological treatment history</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GECKO_0000092 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GECKO_0000092">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OGMS_0000015"/>
-        <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">questionnaire/survey data</obo:GECKO_9000000>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000091"/>
+        <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-pharmacological interventions</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">surgical interventions</obo:GECKO_9000001>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A clinical history that is about surgical operations performed on an individual.</obo:IAO_0000115>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Merge &apos;surgical interventions&apos; into &apos;non-pharmacological interventions&apos;</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">surgical history</rdfs:label>
     </owl:Class>
     
@@ -760,7 +770,7 @@
     <!-- http://purl.obolibrary.org/obo/GECKO_0000093 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GECKO_0000093">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OGMS_0000015"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000115"/>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">questionnaire/survey data</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">medication</obo:GECKO_9000001>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A clinical history that is about the prescription drugs taken by an individual.</obo:IAO_0000115>
@@ -859,6 +869,28 @@
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">availability</obo:GECKO_9000001>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An availability textual entity that is about a substance from an organism (a biosample).</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biosample availability textual entity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GECKO_0000114 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GECKO_0000114">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OGMS_0000015"/>
+        <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">questionnaire/survey data</obo:GECKO_9000000>
+        <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reproduction</obo:GECKO_9000001>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A clinical history that is about pregnancy, maternity, fertility, menses, and any other reproductive aspect.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reproductive history</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GECKO_0000115 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GECKO_0000115">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OGMS_0000015"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A clinical history that is about any treatment (surgical, prescription, etc.) for disease, disorder, or symptom.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">treatment history</rdfs:label>
     </owl:Class>
     
 
@@ -1295,6 +1327,18 @@
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Information about a calendar date or timestamp indicating day, month, year and time of an event.</obo:IAO_0000115>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Replaces GECKO &apos;date and time-related information&apos;</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">date</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000105 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000105">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000034"/>
+        <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">questionnaire/survey data</obo:GECKO_9000000>
+        <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">life stage/time point</obo:GECKO_9000001>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An entire span of an organism&apos;s life, commencing with the zygote stage and ending in the death of the organism.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">life cycle stage</rdfs:label>
     </owl:Class>
     
 

--- a/src/ontology/templates/gecko.tsv
+++ b/src/ontology/templates/gecko.tsv
@@ -37,8 +37,9 @@ GECKO:0000069	alcohol use history	alcohol	lifestyle history	A lifestyle history 
 GECKO:0000071	sleep history	sleep	lifestyle history	A lifestyle history that is about the sleep quality and duration of an individual.		lifestyle and behaviours					
 GECKO:0000072	nutritional history	nutrition	lifestyle history	A lifestyle history that is about the diet and nutrition of an individual.		lifestyle and behaviours					
 GECKO:0000073	physician contact textual entity	physician/practitioner info	textual entity	A textual entity that contains contact details for an individual's physician, which may include: name, phone number, address, etc.		questionnaire/survey data					
-GECKO:0000092	surgical history	surgical interventions	clinical history	A clinical history that is about surgical operations performed on an individual.		questionnaire/survey data					Merge 'surgical interventions' into 'non-pharmacological interventions'
-GECKO:0000093	prescription drug history	medication	clinical history	A clinical history that is about the prescription drugs taken by an individual.		questionnaire/survey data					
+GECKO:0000091	non-pharmacological treatment history	non-pharmacological interventions	treatment history			questionnaire/survey data					
+GECKO:0000092	surgical history	surgical interventions	non-pharmacological treatment history	A clinical history that is about surgical operations performed on an individual.		non-pharmacological interventions					
+GECKO:0000093	prescription drug history	medication	treatment history	A clinical history that is about the prescription drugs taken by an individual.		questionnaire/survey data					
 GECKO:0000094	disease treated by prescription drug	associated disease(s)	information	Information that is about the disease treated by a drug prescribed to an individual.		medication				prescription drug history	
 GECKO:0000096	response to medication	drug response(s)	biological process	A biological process that results from a drug stimulus.		medication					
 GECKO:0000102	summary statistic for federated data	summary statistics for additional data from federated sources	statistic	A statistic that summarizes a set of federated data.		statistics					
@@ -46,6 +47,8 @@ GECKO:0000103	recreational drug history	drugs	lifestyle history	A lifestyle hist
 GECKO:0000104	physical activity history	physical activity	lifestyle history	A lifestyle history that is about the typical physical activity of an individual.		lifestyle and behaviours					
 GECKO:0000106	sample size		count	A count which represents the subset of a collection chosen for an investigation, survey, or assay.							
 GECKO:0000113	biosample availability textual entity	availability	availability textual entity	An availability textual entity that is about a substance from an organism (a biosample).		biosample		organism substance			
+GECKO:0000114	reproductive history	reproduction	clinical history	A clinical history that is about pregnancy, maternity, fertility, menses, and any other reproductive aspect.		questionnaire/survey data					
+GECKO:0000115	treatment history		clinical history	A clinical history that is about any treatment (surgical, prescription, etc.) for disease, disorder, or symptom.							
 IAO:0000619	consent textual entity	consent/accessibility	textual entity	A textual entity that documents the consenting process used to enroll patients in a study.		survey administration					Replaces GECKO 'consent/accessibility'
 MONDO:0000001	disease or disorder	diseases	disposition	A disease is a disposition to undergo pathological processes that exists in an organism because of one or more disorders in that organism.		questionnaire/survey data					Replaces GECKO 'diseases'
 MONDO:0004335	digestive system disease	digestive system	disease or disorder	A disease or disorder that involves the digestive system.		diseases					Replaces GECKO 'digestive system'
@@ -78,3 +81,4 @@ UBERON:0000463	organism substance	sample type	material entity	Material anatomica
 UBERON:0001088	urine	urine	organism substance	Excretion that is the output of a kidney.		sample type					Replaces GECKO 'urine'
 UBERON:0001836	saliva	saliva	organism substance	A fluid produced in the oral cavity by salivary glands, typically used in predigestion, but also in other functions.		sample type					Replaces GECKO 'saliva'
 UBERON:0001988	feces	stool	organism substance	Portion of semisolid bodily waste discharged through the anus.		sample type					Replaces GECKO 'stool'
+UBERON:0000105	life cycle stage	life stage/time point	process	An entire span of an organism's life, commencing with the zygote stage and ending in the death of the organism.		questionnaire/survey data

--- a/views/ihcc-gecko.owl
+++ b/views/ihcc-gecko.owl
@@ -7,7 +7,7 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/ihcc-gecko.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/gecko/2020-07-29/ihcc-gecko.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/gecko/2020-08-20/ihcc-gecko.owl"/>
     </owl:Ontology>
     
 
@@ -396,10 +396,19 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/GECKO_0000091 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GECKO_0000091">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000056"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-pharmacological interventions</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/GECKO_0000092 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GECKO_0000092">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000056"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000091"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">surgical interventions</rdfs:label>
     </owl:Class>
     
@@ -490,6 +499,15 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GECKO_0000113">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000014"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">availability</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GECKO_0000114 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GECKO_0000114">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000056"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reproduction</rdfs:label>
     </owl:Class>
     
 
@@ -733,6 +751,15 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000093">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000052"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">date and time-related information</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000105 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000105">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000056"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">life stage/time point</rdfs:label>
     </owl:Class>
     
 


### PR DESCRIPTION
Add two more categories for the IHCC browser

Label | IHCC Label | Parent | IHCC Category
--- | --- | --- | ---
reproductive history | reproduction | clinical history | questionnaire/survey data |
non-pharmacological treatment history | non-pharmacological interventions | treatment history | questionnaire/survey data |
life cycle stage | life stage/time point | process | questionnaire/survey data |

This also includes the addition of "treatment history" as the parent of "non-pharmacological treatment history" and "prescription drug history":
> A clinical history that is about any treatment (surgical, prescription, etc.) for disease, disorder, or symptom.

I'm OK with removing this if it doesn't make sense.

"life stage/time point" and "non-pharmacological interventions" are both from the CINECA data model, but "reproduction" is a new addition. This is a category that is already used in Maelstrom, and is relevant for many of the cohort mappings.