### PR TITLE
Remove unnecessary annotations from imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,11 @@ build/imports/%.db: src/scripts/prefixes.sql | build/imports/%.owl.gz build/rdft
 build/imports/%.txt: src/ontology/templates/index.tsv | build/imports
 	awk -F '\t' '{print $$1}' $< | tail -n +3 | sed -n '/$(call UC,$(notdir $(basename $@))):/p' > $@
 
-build/imports/%.ttl: build/imports/%.db build/imports/%.txt
-	python3 -m gizmos.extract -d $< -T $(word 2,$^) -n > $@
+build/annotations.txt: src/ontology/templates/properties.tsv
+	grep 'owl:AnnotationProperty$$' $< | grep -v '^GECKO' | cut -f1 > $@
+
+build/imports/%.ttl: build/imports/%.db build/imports/%.txt build/annotations.txt
+	python3 -m gizmos.extract -d $< -T $(word 2,$^) -A $(word 3,$^) -n > $@
 
 src/ontology/annotations.owl: $(IMPORT_MODS) src/queries/fix_annotations.rq build/properties.ttl  | build/robot.jar
 	$(ROBOT) merge \

--- a/gecko.owl
+++ b/gecko.owl
@@ -11,7 +11,7 @@
      xmlns:terms="http://purl.org/dc/terms/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/gecko.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/gecko/releases/2020-10-26/gecko.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/gecko/releases/2020-10-27/gecko.owl"/>
         <dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An ontology to represent genomics cohort attributes.</dc:description>
         <dc:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Genomics Cohorts Knowledge Ontology</dc:title>
         <terms:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
@@ -131,6 +131,14 @@
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">label</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.w3.org/2000/01/rdf-schema#seeAlso -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#seeAlso">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">see also</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -1623,6 +1631,7 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasRelatedSynonym>hematological disorders and malignancies</oboInOwl:hasRelatedSynonym>
         <rdfs:comment>placeholder for lymphoid disease</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hematologic disease</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/monarch-initiative/mondo/issues/254</rdfs:seeAlso>
     </owl:Class>
     
 

--- a/gecko.owl
+++ b/gecko.owl
@@ -11,7 +11,7 @@
      xmlns:terms="http://purl.org/dc/terms/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/gecko.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/gecko/releases/2020-09-18/gecko.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/gecko/releases/2020-10-26/gecko.owl"/>
         <dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An ontology to represent genomics cohort attributes.</dc:description>
         <dc:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Genomics Cohorts Knowledge Ontology</dc:title>
         <terms:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
@@ -31,18 +31,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/BFO_0000179 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000179"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000180 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000180"/>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/GECKO_9000000 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/GECKO_9000000">
@@ -55,14 +43,6 @@
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/GECKO_9000001">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IHCC browser label</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000111 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000111">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">editor preferred term</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -83,22 +63,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000116 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">editor note</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000117 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000117">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">term editor</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/IAO_0000118 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000118">
@@ -112,132 +76,6 @@
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000119">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">definition source</rdfs:label>
     </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000232 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000232">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">curator note</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000233 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000233">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">term tracker item</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000234 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000234">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ontology term requester</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000600 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000600"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000601 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000601"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000602 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000602"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0001847 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0001847"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_9991118 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OBI_9991118"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/STATO_0000032 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/STATO_0000032"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000001 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000001">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">external_definition</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000002 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000002">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">axiom_lost_from_external_ontology</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000003 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000003">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">homology_notes</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000007 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000007">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_relational_adjective</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000008 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000008">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">taxon_notes</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000012 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000012">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">external_ontology_notes</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.org/dc/elements/1.1/source -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/source"/>
-    
-
-
-    <!-- http://www.geneontology.org/formats/oboInOwl#created_by -->
-
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#created_by"/>
-    
-
-
-    <!-- http://www.geneontology.org/formats/oboInOwl#creation_date -->
-
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#creation_date"/>
     
 
 
@@ -257,12 +95,6 @@
     
 
 
-    <!-- http://www.geneontology.org/formats/oboInOwl#hasDbXref -->
-
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-    
-
-
     <!-- http://www.geneontology.org/formats/oboInOwl#hasExactSynonym -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym">
@@ -279,34 +111,10 @@
     
 
 
-    <!-- http://www.geneontology.org/formats/oboInOwl#hasOBONamespace -->
-
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasOBONamespace">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_obo_namespace</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
     <!-- http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_related_synonym</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://www.geneontology.org/formats/oboInOwl#id -->
-
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#id">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">id</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://www.geneontology.org/formats/oboInOwl#inSubset -->
-
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#inSubset">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">in_subset</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -323,14 +131,6 @@
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">label</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://www.w3.org/2000/01/rdf-schema#seeAlso -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#seeAlso">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">see also</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -384,8 +184,6 @@
     <!-- http://purl.obolibrary.org/obo/BFO_0000015 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000015">
-        <obo:BFO_0000179>process</obo:BFO_0000179>
-        <obo:BFO_0000180>Process</obo:BFO_0000180>
         <obo:IAO_0000112 xml:lang="en">a process of cell-division, \ a beating of the heart</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">a process of meiosis</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">a process of sleeping</obo:IAO_0000112>
@@ -394,9 +192,7 @@
         <obo:IAO_0000112 xml:lang="en">the life of an organism</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">your process of aging.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">p is a process = Def. p is an occurrent that has temporal proper parts and for some time t, p s-depends_on some material entity at t. (axiom label in BFO2 Reference: [083-003])</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: The realm of occurrents is less pervasively marked by the presence of natural units than is the case in the realm of independent continuants. Thus there is here no counterpart of ‘object’. In BFO 1.0 ‘process’ served as such a counterpart. In BFO 2.0 ‘process’ is, rather, the occurrent counterpart of ‘material entity’. Those natural – as contrasted with engineered, which here means: deliberately executed – units which do exist in the realm of occurrents are typically either parasitic on the existence of natural units on the continuant side, or they are fiat in nature. Thus we can count lives; we can count football games; we can count chemical reactions performed in experiments or in chemical manufacturing. We cannot count the processes taking place, for instance, in an episode of insect mating behavior.Even where natural units are identifiable, for example cycles in a cyclical process such as the beating of a heart or an organism’s sleep/wake cycle, the processes in question form a sequence with no discontinuities (temporal gaps) of the sort that we find for instance where billiard balls or zebrafish or planets are separated by clear spatial gaps. Lives of organisms are process units, but they too unfold in a continuous series from other, prior processes such as fertilization, and they unfold in turn in continuous series of post-life processes such as post-mortem decay. Clear examples of boundaries of processes are almost always of the fiat sort (midnight, a time of death as declared in an operating theater or on a death certificate, the initiation of a state of war)</obo:IAO_0000116>
-        <obo:IAO_0000602>(iff (Process a) (and (Occurrent a) (exists (b) (properTemporalPartOf b a)) (exists (c t) (and (MaterialEntity c) (specificallyDependsOnAt a c t))))) // axiom label in BFO2 CLIF: [083-003]</obo:IAO_0000602>
-        <rdfs:label>process</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">process</rdfs:label>
     </owl:Class>
     
 
@@ -405,18 +201,11 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000016">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
-        <obo:BFO_0000179>disposition</obo:BFO_0000179>
-        <obo:BFO_0000180>Disposition</obo:BFO_0000180>
         <obo:IAO_0000112 xml:lang="en">an atom of element X has the disposition to decay to an atom of element Y</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">certain people have a predisposition to colon cancer</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">children are innately disposed to categorize objects in certain ways.</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the cell wall is disposed to filter chemicals in endocytosis and exocytosis</obo:IAO_0000112>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Dispositions exist along a strength continuum. Weaker forms of disposition are realized in only a fraction of triggering cases. These forms occur in a significant number of cases of a similar type.</obo:IAO_0000116>
-        <obo:IAO_0000600 xml:lang="en">b is a disposition means: b is a realizable entity &amp; b’s bearer is some material entity &amp; b is such that if it ceases to exist, then its bearer is physically changed, &amp; b’s realization occurs when and because this bearer is in some special physical circumstances, &amp; this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])</obo:IAO_0000600>
-        <obo:IAO_0000601 xml:lang="en">If b is a realizable entity then for all t at which b exists, b s-depends_on some material entity at t. (axiom label in BFO2 Reference: [063-002])</obo:IAO_0000601>
-        <obo:IAO_0000602>(forall (x t) (if (and (RealizableEntity x) (existsAt x t)) (exists (y) (and (MaterialEntity y) (specificallyDepends x y t))))) // axiom label in BFO2 CLIF: [063-002]</obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (Disposition x) (and (RealizableEntity x) (exists (y) (and (MaterialEntity y) (bearerOfAt x y t)))))) // axiom label in BFO2 CLIF: [062-002]</obo:IAO_0000602>
-        <rdfs:label>disposition</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disposition</rdfs:label>
     </owl:Class>
     
 
@@ -424,17 +213,11 @@
     <!-- http://purl.obolibrary.org/obo/BFO_0000017 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000017">
-        <obo:BFO_0000179>realizable</obo:BFO_0000179>
-        <obo:BFO_0000180>RealizableEntity</obo:BFO_0000180>
         <obo:IAO_0000112 xml:lang="en">the disposition of this piece of metal to conduct electricity.</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the disposition of your blood to coagulate</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the function of your reproductive organs</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the role of being a doctor</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the role of this boundary to delineate where Utah and Colorado meet</obo:IAO_0000112>
-        <obo:IAO_0000600 xml:lang="en">To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])</obo:IAO_0000600>
-        <obo:IAO_0000601 xml:lang="en">All realizable dependent continuants have independent continuants that are not spatial regions as their bearers. (axiom label in BFO2 Reference: [060-002])</obo:IAO_0000601>
-        <obo:IAO_0000602>(forall (x t) (if (RealizableEntity x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (bearerOfAt y x t))))) // axiom label in BFO2 CLIF: [060-002]</obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (RealizableEntity x) (and (SpecificallyDependentContinuant x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (inheresIn x y)))))) // axiom label in BFO2 CLIF: [058-002]</obo:IAO_0000602>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">realizable entity</rdfs:label>
     </owl:Class>
     
@@ -443,19 +226,13 @@
     <!-- http://purl.obolibrary.org/obo/BFO_0000019 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000019">
-        <obo:BFO_0000179>quality</obo:BFO_0000179>
-        <obo:BFO_0000180>Quality</obo:BFO_0000180>
         <obo:IAO_0000112 xml:lang="en">the ambient temperature of this portion of air</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the color of a tomato</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the length of the circumference of your waist</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the mass of this piece of gold.</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the shape of your nose</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the shape of your nostril</obo:IAO_0000112>
-        <obo:IAO_0000600 xml:lang="en">a quality is a specifically dependent continuant that, in contrast to roles and dispositions, does not require any further process in order to be realized. (axiom label in BFO2 Reference: [055-001])</obo:IAO_0000600>
-        <obo:IAO_0000601 xml:lang="en">If an entity is a quality at any time that it exists, then it is a quality at every time that it exists. (axiom label in BFO2 Reference: [105-001])</obo:IAO_0000601>
-        <obo:IAO_0000602>(forall (x) (if (Quality x) (SpecificallyDependentContinuant x))) // axiom label in BFO2 CLIF: [055-001]</obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (exists (t) (and (existsAt x t) (Quality x))) (forall (t_1) (if (existsAt x t_1) (Quality x))))) // axiom label in BFO2 CLIF: [105-001]</obo:IAO_0000602>
-        <rdfs:label>quality</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">quality</rdfs:label>
     </owl:Class>
     
 
@@ -464,8 +241,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000029">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000141"/>
-        <obo:BFO_0000179>site</obo:BFO_0000179>
-        <obo:BFO_0000180>Site</obo:BFO_0000180>
         <obo:IAO_0000112 xml:lang="en">Manhattan Canyon)</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">a hole in the interior of a portion of cheese</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">a rabbit hole</obo:IAO_0000112>
@@ -481,9 +256,7 @@
         <obo:IAO_0000112 xml:lang="en">the interior of your refrigerator</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the lumen of your gut</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">your left nostril (a fiat part – the opening – of your left nasal cavity)</obo:IAO_0000112>
-        <obo:IAO_0000600 xml:lang="en">b is a site means: b is a three-dimensional immaterial entity that is (partially or wholly) bounded by a material entity or it is a three-dimensional immaterial part thereof. (axiom label in BFO2 Reference: [034-002])</obo:IAO_0000600>
-        <obo:IAO_0000602>(forall (x) (if (Site x) (ImmaterialEntity x))) // axiom label in BFO2 CLIF: [034-002]</obo:IAO_0000602>
-        <rdfs:label>site</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">site</rdfs:label>
     </owl:Class>
     
 
@@ -491,8 +264,6 @@
     <!-- http://purl.obolibrary.org/obo/BFO_0000040 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000040">
-        <obo:BFO_0000179>material</obo:BFO_0000179>
-        <obo:BFO_0000180>MaterialEntity</obo:BFO_0000180>
         <obo:IAO_0000112 xml:lang="en">a flame</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">a forest fire</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">a human being</obo:IAO_0000112>
@@ -505,15 +276,6 @@
         <obo:IAO_0000112 xml:lang="en">an energy wave</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">an epidemic</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the undetached arm of a human being</obo:IAO_0000112>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Material entities (continuants) can preserve their identity even while gaining and losing material parts. Continuants are contrasted with occurrents, which unfold themselves in successive temporal parts or phases [60</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Object, Fiat Object Part and Object Aggregate are not intended to be exhaustive of Material Entity. Users are invited to propose new subcategories of Material Entity.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: ‘Matter’ is intended to encompass both mass and energy (we will address the ontological treatment of portions of energy in a later version of BFO). A portion of matter is anything that includes elementary particles among its proper or improper parts: quarks and leptons, including electrons, as the smallest particles thus far discovered; baryons (including protons and neutrons) at a higher level of granularity; atoms and molecules at still higher levels, forming the cells, organs, organisms and other material entities studied by biologists, the portions of rock studied by geologists, the fossils studied by paleontologists, and so on.Material entities are three-dimensional entities (entities extended in three spatial dimensions), as contrasted with the processes in which they participate, which are four-dimensional entities (entities extended also along the dimension of time).According to the FMA, material entities may have immaterial entities as parts – including the entities identified below as sites; for example the interior (or ‘lumen’) of your small intestine is a part of your body. BFO 2.0 embodies a decision to follow the FMA here.</obo:IAO_0000116>
-        <obo:IAO_0000600 xml:lang="en">A material entity is an independent continuant that has some portion of matter as proper or improper continuant part. (axiom label in BFO2 Reference: [019-002])</obo:IAO_0000600>
-        <obo:IAO_0000601 xml:lang="en">Every entity which has a material entity as continuant part is a material entity. (axiom label in BFO2 Reference: [020-002])</obo:IAO_0000601>
-        <obo:IAO_0000601 xml:lang="en">every entity of which a material entity is continuant part is also a material entity. (axiom label in BFO2 Reference: [021-002])</obo:IAO_0000601>
-        <obo:IAO_0000602>(forall (x) (if (MaterialEntity x) (IndependentContinuant x))) // axiom label in BFO2 CLIF: [019-002]</obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (and (Entity x) (exists (y t) (and (MaterialEntity y) (continuantPartOfAt x y t)))) (MaterialEntity x))) // axiom label in BFO2 CLIF: [021-002]</obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (and (Entity x) (exists (y t) (and (MaterialEntity y) (continuantPartOfAt y x t)))) (MaterialEntity x))) // axiom label in BFO2 CLIF: [020-002]</obo:IAO_0000602>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">material entity</rdfs:label>
     </owl:Class>
     
@@ -522,9 +284,6 @@
     <!-- http://purl.obolibrary.org/obo/BFO_0000141 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000141">
-        <obo:BFO_0000179>immaterial</obo:BFO_0000179>
-        <obo:BFO_0000180>ImmaterialEntity</obo:BFO_0000180>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Immaterial entities are divided into two subgroups:boundaries and sites, which bound, or are demarcated in relation, to material entities, and which can thus change location, shape and size and as their material hosts move or change shape or size (for example: your nasal passage; the hold of a ship; the boundary of Wales (which moves with the rotation of the Earth) [38, 7, 10</obo:IAO_0000116>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">immaterial entity</rdfs:label>
     </owl:Class>
     
@@ -614,9 +373,7 @@
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">other questionnaire/survey data</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cause of death</obo:GECKO_9000001>
         <obo:IAO_0000115>An information content entity indicating the cause of death for a participant in the study.</obo:IAO_0000115>
-        <obo:IAO_0000117>Person:  Jie Zheng, Chris Stoeckert, David Roos, Grant Dorsey</obo:IAO_0000117>
         <obo:IAO_0000119>Penn Group</obo:IAO_0000119>
-        <dc:source>PRISM</dc:source>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cause of participant death</rdfs:label>
     </owl:Class>
     
@@ -629,9 +386,7 @@
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">healthcare information</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hospitalizations</obo:GECKO_9000001>
         <obo:IAO_0000115 xml:lang="en">an information content entity that is about a part of a health care encounter that occurs in a hospital facility</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Person: John Judkins</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">EuPathDB</obo:IAO_0000119>
-        <oboInOwl:inSubset>ICEMR protein array</oboInOwl:inSubset>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hospitalization information</rdfs:label>
     </owl:Class>
     
@@ -656,7 +411,6 @@
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">socio-demographic and economic characteristics</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">marital status</obo:GECKO_9000001>
         <obo:IAO_0000115 xml:lang="en">a categorical value specification that is about a human being and specifies whether that human being is joined to another human being in marriage</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Person: John Judkins</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">EuPathDB, BFO&apos;s &apos;relational quality&apos; examples</obo:IAO_0000119>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">marital status</rdfs:label>
     </owl:Class>
@@ -682,9 +436,7 @@
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">questionnaire/survey data</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">physical environment</obo:GECKO_9000001>
         <obo:IAO_0000115>environmental system associated with the dwelling used by humans.</obo:IAO_0000115>
-        <obo:IAO_0000117>Person:  Cristian Cocos, Jie Zheng, Chris Stoeckert</obo:IAO_0000117>
         <obo:IAO_0000119>Penn Group</obo:IAO_0000119>
-        <dc:source>GEMS</dc:source>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">environment associated with human dwelling</rdfs:label>
     </owl:Class>
     
@@ -1403,20 +1155,15 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0008150">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
         <obo:IAO_0000115>A biological process represents a specific objective that the organism is genetically programmed to achieve. Biological processes are often described by their outcome or ending state, e.g., the biological process of cell division results in the creation of two daughter cells (a divided cell) from a single parent cell. A biological process is accomplished by a particular set of molecular functions carried out by specific gene products (or macromolecular complexes), often in a highly regulated manner and in a particular temporal sequence.</obo:IAO_0000115>
-        <oboInOwl:created_by>jl</oboInOwl:created_by>
-        <oboInOwl:creation_date>2012-09-19T15:05:24Z</oboInOwl:creation_date>
         <oboInOwl:hasAlternativeId>GO:0000004</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>GO:0007582</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>GO:0044699</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref>Wikipedia:Biological_process</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>biological process</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>physiological process</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>biological_process</oboInOwl:hasOBONamespace>
         <oboInOwl:hasRelatedSynonym>single organism process</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>single-organism process</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>GO:0008150</oboInOwl:id>
         <rdfs:comment>Note that, in addition to forming the root of the biological process ontology, this term is recommended for use for the annotation of gene products whose biological process is unknown. When this term is used for annotation, it indicates that no information was available about the biological process of the gene product annotated as of the date the annotation was made; the evidence code &apos;no data&apos; (ND), is used to indicate this.</rdfs:comment>
-        <rdfs:label>biological_process</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biological_process</rdfs:label>
     </owl:Class>
     
 
@@ -1427,16 +1174,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000033"/>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">basic cohort attributes</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aims and objectives</obo:GECKO_9000001>
-        <obo:IAO_0000111 xml:lang="en">objective specification</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">In the protocol of a ChIP assay the objective specification says to identify protein and DNA interaction.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A directive information entity that describes an intended process endpoint. When part of a plan specification the concretization is realized in a planned process in which the bearer tries to effect the world so that the process endpoint is achieved.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">2009-03-16: original definition when imported from OBI read: &quot;objective is an non realizable information entity which can serve as that  proper part of a plan towards which the realization of the plan is directed.&quot;</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">2014-03-31: In the example of usage (&quot;In the protocol of a ChIP assay the objective specification says to identify protein and DNA interaction&quot;) there is a protocol which is the ChIP assay protocol. In addition to being concretized on paper, the protocol can be concretized as a realizable entity, such as a plan that inheres in a person. The objective specification is the part that says that some protein and DNA interactions are identified. This is a specification of a process endpoint: the boundary in the process before which they are not identified and after which they are. During the realization of the plan, the goal is to get to the point of having the interactions, and participants in the realization of the plan try to do that.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">Answers the question, why did you do this experiment?</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Barry Smith</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Bjoern Peters</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Jennifer Fostel</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">goal specification</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">OBI Plan and Planned Process/Roles Branch</obo:IAO_0000119>
         <obo:IAO_0000119 xml:lang="en">OBI_0000217</obo:IAO_0000119>
@@ -1449,13 +1188,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000027">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
-        <obo:IAO_0000111 xml:lang="en">data item</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">Data items include counts of things, analyte concentrations, and statistical summaries.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">An information content entity that is intended to be a truthful statement about something (modulo, e.g., measurement precision or other systematic errors) and is constructed/acquired by a method which reliably tends to produce (approximately) truthful statements.</obo:IAO_0000115>
-        <obo:IAO_0000116>2014-03-31: See discussion at http://odontomachus.wordpress.com/2014/03/30/aboutness-objects-propositions/</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Chris Stoeckert</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Jonathan Rees</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">data</obo:IAO_0000118>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">data item</rdfs:label>
     </owl:Class>
@@ -1465,14 +1199,8 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000030 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000030">
-        <obo:IAO_0000111 xml:lang="en">information content entity</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">Examples of information content entites include journal articles, data, graphical layouts, and graphs.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A generically dependent continuant that is about some thing.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">2014-03-10: The use of &quot;thing&quot; is intended to be general enough to include universals and configurations (see https://groups.google.com/d/msg/information-ontology/GBxvYZCk1oc/-L6B5fSBBTQJ).</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">information_content_entity &apos;is_encoded_in&apos; some digital_entity in obi before split (040907). information_content_entity &apos;is_encoded_in&apos; some physical_document in obi before split (040907).
-
-Previous. An information content entity is a non-realizable information entity that &apos;is encoded in&apos; some digital or physical entity.</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Chris Stoeckert</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">OBI_0000142</obo:IAO_0000119>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">information content entity</rdfs:label>
     </owl:Class>
@@ -1484,12 +1212,6 @@ Previous. An information content entity is a non-realizable information entity t
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000033">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
         <obo:IAO_0000115 xml:lang="en">An information content entity whose concretizations indicate to their bearer how to realize them in a process.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">2009-03-16: provenance: a term realizable information entity was proposed for OBI (OBI_0000337) , edited by the PlanAndPlannedProcess branch. Original definition was  &quot;is the specification of a process that can be concretized and realized by an actor&quot; with alternative term  &quot;instruction&quot;.It has been subsequently moved to IAO where the objective for which the original term was defined was satisfied with the definitionof this, different, term.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">2013-05-30 Alan Ruttenberg: What differentiates a directive information entity from an information concretization is that it can have concretizations that are either qualities or realizable entities. The concretizations that are realizable entities are created when an individual chooses to take up the direction, i.e. has the intention to (try to) realize it.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">8/6/2009 Alan Ruttenberg: Changed label from &quot;information entity about a realizable&quot; after discussions at ICBO</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">Werner pushed back on calling it realizable information entity as it isn&apos;t realizable. However this name isn&apos;t right either. An example would be a recipe. The realizable entity would be a plan, but the information entity isn&apos;t about the plan, it, once concretized, *is* the plan. -Alan</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Bjoern Peters</obo:IAO_0000117>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">directive information entity</rdfs:label>
     </owl:Class>
     
@@ -1499,13 +1221,8 @@ Previous. An information content entity is a non-realizable information entity t
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000104">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000033"/>
-        <obo:IAO_0000111 xml:lang="en">plan specification</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">PMID: 18323827.Nat Med. 2008 Mar;14(3):226.New plan proposed to help resolve conflicting medical advice.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A directive information entity with action specifications and objective specifications as parts that, when concretized, is realized in a process in which the bearer tries to achieve the objectives by taking the actions specified.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">2009-03-16: provenance: a term a plan was proposed for OBI (OBI_0000344) , edited by the PlanAndPlannedProcess branch. Original definition was &quot; a plan is a specification of a process that is realized by an actor to achieve the objective specified as part of the plan&quot;. It has been subsequently moved to IAO where the objective for which the original term was defined was satisfied with the definitionof this, different, term.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">2014-03-31: A plan specification can have other parts, such as conditional specifications.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">Alternative previous definition: a plan is a set of instructions that specify how an objective should be achieved</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">OBI Plan and Planned Process branch</obo:IAO_0000119>
         <obo:IAO_0000119 xml:lang="en">OBI_0000344</obo:IAO_0000119>
         <rdfs:comment xml:lang="en">2/3/2009 Comment from OBI review.
@@ -1524,11 +1241,8 @@ Request that IAO either clarify these or change definitions not to use them</rdf
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000109">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
-        <obo:IAO_0000111 xml:lang="en">measurement datum</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">Examples of measurement data are the recoding of the weight of a mouse as {40,mass,&quot;grams&quot;}, the recording of an observation of the behavior of the mouse {,process,&quot;agitated&quot;}, the recording of the expression level of a gene as measured through the process of microarray experiment {3.4,luminosity,}.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A measurement datum is an information content entity that is a recording of the output of a measurement such as produced by a device.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">2/2/2009 is_specified_output of some assay?</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">person:Chris Stoeckert</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">OBI_0000305</obo:IAO_0000119>
         <obo:IAO_0000119 xml:lang="en">group:OBI</obo:IAO_0000119>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">measurement datum</rdfs:label>
@@ -1540,12 +1254,8 @@ Request that IAO either clarify these or change definitions not to use them</rdf
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000300">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
-        <obo:IAO_0000111 xml:lang="en">textual entity</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">Words, sentences, paragraphs, and the written (non-figure) parts of publications are all textual entities</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A textual entity is a part of a manifestation (FRBR sense), a generically dependent continuant whose concretizations are patterns of glyphs intended to be interpreted as words, formulas, etc.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">AR, (IAO call 2009-09-01): a document as a whole is not typically a textual entity, because it has pictures in it - rather there are parts of it that are textual entities. Examples: The title, paragraph 2 sentence 7, etc.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">MC, 2009-09-14 (following IAO call 2009-09-01): textual entities live at the FRBR (http://en.wikipedia.org/wiki/Functional_Requirements_for_Bibliographic_Records) manifestation level. Everything is significant: line break, pdf and html versions of same document are different textual entities.</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Lawrence Hunter</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">text</obo:IAO_0000118>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">textual entity</rdfs:label>
     </owl:Class>
@@ -1556,10 +1266,8 @@ Request that IAO either clarify these or change definitions not to use them</rdf
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000310">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
-        <obo:IAO_0000111 xml:lang="en">document</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">A journal article, patent application, laboratory notebook, or a book</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A collection of information content entities intended to be understood together as a whole</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Lawrence Hunter</obo:IAO_0000117>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">document</rdfs:label>
     </owl:Class>
     
@@ -1569,12 +1277,10 @@ Request that IAO either clarify these or change definitions not to use them</rdf
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000612">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000300"/>
-        <obo:IAO_0000111 xml:lang="en">availability textual entity</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">From Qi et al. BMC Bioinformatics. 2014; 15: 11. (http://www.ncbi.nlm.nih.gov/pmc/articles/PMC3897912/):
 
 Project home page:http://krux.googlecode.com</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A textual entity expressing the location of a resource, e.g. software, or the manner in which a resource can be obtained.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Bill Baumgartner</obo:IAO_0000117>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">availability textual entity</rdfs:label>
     </owl:Class>
     
@@ -1586,12 +1292,10 @@ Project home page:http://krux.googlecode.com</obo:IAO_0000112>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000300"/>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">survey administration</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">consent/accessibility</obo:GECKO_9000001>
-        <obo:IAO_0000111 xml:lang="en">consent textual entity</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">From Shiba et al. Acta Neuropathol Commun. 2013; 1: 45. (http://www.ncbi.nlm.nih.gov/pmc/articles/PMC3893467/):
 
 Written informed consent was obtained from the patient’s parents for publication of this Case report and any accompanying images. A copy of the written consent is available for review by the Editor-in chief of this journal.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A textual entity that documents the consenting process used to enroll patients in a study.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Bill Baumgartner</obo:IAO_0000117>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">consent textual entity</rdfs:label>
     </owl:Class>
     
@@ -1601,7 +1305,6 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0020000">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
-        <obo:IAO_0000111 xml:lang="en">identifier</obo:IAO_0000111>
         <obo:IAO_0000115 xml:lang="en">An identifier is an information content entity that is the outcome of a dubbing process and is used to refer to one instance of entity shared by a group of people to refer to that individual entity.</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">identifier</rdfs:label>
     </owl:Class>
@@ -1626,16 +1329,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">questionnaire/survey data</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases</obo:GECKO_9000001>
         <obo:IAO_0000115>A disease is a disposition to undergo pathological processes that exists in an organism because of one or more disorders in that organism.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>DOID:4</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000408</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:N18</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:799.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D004194</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C2991</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>OGMS:0000031</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Orphanet:377788</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:64572001</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0012634</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>condition</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disease or disorder</oboInOwl:hasExactSynonym>
@@ -1646,7 +1339,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>disorders</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>medical condition</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>other disease</oboInOwl:hasExactSynonym>
-        <oboInOwl:id>MONDO:0000001</oboInOwl:id>
         <rdfs:label>disease or disorder</rdfs:label>
     </owl:Class>
     
@@ -1660,9 +1352,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">skin and subcutaneous tissue</obo:GECKO_9000001>
         <obo:IAO_0000115>A disease involving the integumental system.</obo:IAO_0000115>
         <oboInOwl:hasAlternativeId>MONDO:0045027</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref>DOID:16</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:128598002</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C1290011</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>disease of integumental system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disease or disorder of integumental system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disorder of integumental system</oboInOwl:hasExactSynonym>
@@ -1671,7 +1360,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>integumentary disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of integument</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of integumental system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0002051</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">integumentary system disease</rdfs:label>
     </owl:Class>
     
@@ -1684,12 +1372,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">musculoskeletal system</obo:GECKO_9000001>
         <obo:IAO_0000115>A disease involving the musculoskeletal system.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>DOID:17</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:729.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D009140</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C107377</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:928000</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0026857</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>disease of musculoskeletal system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disease or disorder of musculoskeletal system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disorder of musculoskeletal system</oboInOwl:hasExactSynonym>
@@ -1699,7 +1381,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>musculoskeletal system disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of musculoskeletal system</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>musculoskeletal disorder</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0002081</oboInOwl:id>
         <rdfs:label>musculoskeletal system disease</rdfs:label>
     </owl:Class>
     
@@ -1712,12 +1393,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">connective tissue</obo:GECKO_9000001>
         <obo:IAO_0000115>A disease involving the connective tissue.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>COHD:253549</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>DOID:65</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D003240</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C26729</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:105969002</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0009782</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>connective tissue disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>connective tissue disease or disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>connective tissue diseases</oboInOwl:hasExactSynonym>
@@ -1730,7 +1405,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>primary disorder of connective tissue</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>tissue disease, connective</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of connective tissue</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0003900</oboInOwl:id>
         <rdfs:label>connective tissue disease</rdfs:label>
     </owl:Class>
     
@@ -1743,15 +1417,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">digestive system</obo:GECKO_9000001>
         <obo:IAO_0000115>A disease or disorder that involves the digestive system.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>COHD:4201745</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>DOID:77</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000405</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:K92.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:520-579.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:V47.3</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D005767</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C2990</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:53619000</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>alimentary system disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>digestive disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>digestive system disease</oboInOwl:hasExactSynonym>
@@ -1770,7 +1435,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>git disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>stomach or intestinal disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of digestive system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0004335</oboInOwl:id>
         <rdfs:label>digestive system disease</rdfs:label>
     </owl:Class>
     
@@ -1783,23 +1447,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">oncological</obo:GECKO_9000001>
         <obo:IAO_0000115>A tumor composed of atypical neoplastic, often pleomorphic cells that invade other tissues. Malignant neoplasms often metastasize to distant anatomic sites and may recur after excision. The most common malignant neoplasms are carcinomas (adenocarcinomas or squamous cell carcinomas), Hodgkin and non-Hodgkin lymphomas, leukemias, melanomas, and sarcomas.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>COHD:443392</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>DOID:0050686</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>DOID:0050687</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>DOID:162</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000311</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>GARD:0011960</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:C80</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:C80.1</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:195.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:199</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:199.1</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICDO:8000/3</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C9305</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NIFSTD:birnlex_406</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ONCOTREE:MT</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:363346000</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0006826</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>CA</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>cancer</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>cell type cancer</oboInOwl:hasExactSynonym>
@@ -1814,7 +1461,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>organ system cancer</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>primary cancer</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>MT</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0004992</oboInOwl:id>
         <rdfs:label>cancer</rdfs:label>
     </owl:Class>
     
@@ -1827,26 +1473,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circulatory system</obo:GECKO_9000001>
         <obo:IAO_0000115>A disease involving the cardiovascular system.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>DOID:1287</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000319</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:I00.I99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:390-459.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:420-429.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:423</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:423.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:424</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:429</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:429.2</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:429.7</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:429.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:429.81</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:429.89</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:459.89</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:459.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D002318</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C2931</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:49601007</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0007222</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>cardiovascular disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>cardiovascular disease (CVD)</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>cardiovascular disorder</oboInOwl:hasExactSynonym>
@@ -1858,7 +1484,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>disorder of cardiovascular system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>circulatory system disease</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of cardiovascular system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0004995</oboInOwl:id>
         <rdfs:label>cardiovascular disease</rdfs:label>
     </owl:Class>
     
@@ -1871,19 +1496,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nervous system</obo:GECKO_9000001>
         <obo:IAO_0000115>A non-neoplastic or neoplastic disorder that affects the brain, spinal cord, or peripheral nerves.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>DOID:863</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000618</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:G00-G99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:G00.G99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:G98</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:G98.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:349.89</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:349.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D009422</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C26835</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:118940003</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0027765</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Wikipedia:Nervous_system_disease</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>disease of nervous system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disease or disorder of nervous system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disorder of nervous system</oboInOwl:hasExactSynonym>
@@ -1895,7 +1507,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>neurological disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>neurological disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of nervous system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005071</oboInOwl:id>
         <rdfs:label>nervous system disorder</rdfs:label>
     </owl:Class>
     
@@ -1908,19 +1519,10 @@ Written informed consent was obtained from the patient’s parents for publicati
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mental and behaviour disorders</obo:GECKO_9000001>
         <obo:IAO_0000115>A disease that has its basis in the disruption of mental process.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>EFO:0000677</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:F00.F99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:290-299.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:298.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:V11.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NIFSTD:birnlex_12669</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:74732009</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:CN240636</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>disorder of mental process</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>mental or behavioural disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>mental process disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of mental process</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005084</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mental disorder</rdfs:label>
     </owl:Class>
     
@@ -1933,33 +1535,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">respiratory system</obo:GECKO_9000001>
         <obo:IAO_0000115>A non-neoplastic or neoplastic disorder that affects the respiratory system. Representative examples include pneumonia, chronic obstructive pulmonary disease, pulmonary failure, lung adenoma, lung carcinoma, and tracheal carcinoma.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>DOID:1579</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000684</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:J96-J99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:J98</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:460-519.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:500-508.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:503</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:508</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:508.1</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:508.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:508.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:510-519.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:516</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:516.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:516.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:517</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:517.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:519</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:519.1</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:519.3</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:519.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:519.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:V12.60</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:V47.2</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D012140</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C26871</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:50043002</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>disease of respiratory system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disease or disorder of respiratory system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disorder of respiratory system</oboInOwl:hasExactSynonym>
@@ -1969,7 +1544,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>respiratory system disease or disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>respiratory system disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of respiratory system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005087</oboInOwl:id>
         <rdfs:label>respiratory system disease</rdfs:label>
     </owl:Class>
     
@@ -1982,15 +1556,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">endocrine/nutritional/metabolic disorders</obo:GECKO_9000001>
         <obo:IAO_0000115>A disease involving the endocrine system.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>DOID:28</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0001379</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:E34.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:259.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:259.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D004700</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C3009</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:362969004</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0014130</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>disease of endocrine system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disease or disorder of endocrine system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disorder of endocrine system</oboInOwl:hasExactSynonym>
@@ -2002,7 +1567,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>endocrinopathy</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>thyroid or other glandular disorders</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of endocrine system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005151</oboInOwl:id>
         <rdfs:label>endocrine system disease</rdfs:label>
     </owl:Class>
     
@@ -2015,16 +1579,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">infectious disease</obo:GECKO_9000001>
         <obo:IAO_0000115>A disorder resulting from the presence and activity of a microbial, viral, or parasitic agent. It can be transmitted by direct or indirect contact.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>DOID:0050117</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0005741</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:A00.B99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:079.0</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:136.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:136.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>IDO:0000436</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D003141</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C26726</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:40733004</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>ID</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>clinical infection</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>communicable disease</oboInOwl:hasExactSynonym>
@@ -2035,7 +1589,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>infectious disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>transmissible disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disease by infectious agent</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005550</oboInOwl:id>
         <rdfs:comment>Replaces &apos;infection&apos; in disease hierarchy. OBI imported term infection is moved to pathologic process. This class is a container class for infectious diseases, not the process of infection itself.</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">infectious disease</rdfs:label>
     </owl:Class>
@@ -2049,20 +1602,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">blood-related disorders</obo:GECKO_9000001>
         <obo:IAO_0000115>A disease involving the hematopoietic system.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>DOID:74</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0005803</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>GTR:AN1320635</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:D75.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:280-289.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:289.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:289.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D006402</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C26323</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Orphanet:97992</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:414022008</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0018939</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:CN206939</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:CN882913</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>blood disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>blood disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>blood dyscrasia</oboInOwl:hasExactSynonym>
@@ -2082,10 +1621,8 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasRelatedSynonym>blood dyscrasia NOS</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of hematopoietic system</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>hematological disorders and malignancies</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005570</oboInOwl:id>
         <rdfs:comment>placeholder for lymphoid disease</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hematologic disease</rdfs:label>
-        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/monarch-initiative/mondo/issues/254</rdfs:seeAlso>
     </owl:Class>
     
 
@@ -2097,16 +1634,10 @@ Written informed consent was obtained from the patient’s parents for publicati
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">injury</obo:GECKO_9000001>
         <obo:IAO_0000115>Damage inflicted on the body as the direct or indirect result of an external force, with or without disruption of structural continuity.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>COHD:440921</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000546</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:S00.T98</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D014947</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C3671</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">injury</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>trauma</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>traumatic injury</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>wound</oboInOwl:hasExactSynonym>
-        <oboInOwl:id>MONDO:0021178</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">injury</rdfs:label>
     </owl:Class>
     
@@ -2119,7 +1650,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual system</obo:GECKO_9000001>
         <obo:IAO_0000115>A disease that involves the visual system.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>SCTID:128127008</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>disease of visual system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disease or disorder of visual system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disorder of visual system</oboInOwl:hasExactSynonym>
@@ -2127,7 +1657,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>visual system disease or disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>visual system disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of visual system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0024458</oboInOwl:id>
         <rdfs:label>disease of visual system</rdfs:label>
     </owl:Class>
     
@@ -2140,12 +1669,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases of the ear, nose, and/or throat</obo:GECKO_9000001>
         <obo:IAO_0000115>Pathological processes of the ear, the nose, and the throat, also known as the ENT diseases.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>ICD9:478.19</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D010038</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C118420</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:232208008</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0029896</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0395797</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>ear, nose and throat disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>ear, nose or throat disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>ear/nose/throat disease</oboInOwl:hasExactSynonym>
@@ -2169,7 +1692,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasRelatedSynonym>otolaryngological diseases</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>otorhinolaryngological disease</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>otorhinolaryngological diseases</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0024623</oboInOwl:id>
         <rdfs:comment>Editor note: consider uberon class</rdfs:comment>
         <rdfs:label>otorhinolaryngologic disease</rdfs:label>
     </owl:Class>
@@ -2183,14 +1705,9 @@ Written informed consent was obtained from the patient’s parents for publicati
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">poisoning</obo:GECKO_9000001>
         <obo:IAO_0000115>A condition or physical state produced by the ingestion, injection, inhalation of or exposure to a deleterious agent.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>EFO:0008546</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D011041</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:75478009</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0302332</oboInOwl:hasDbXref>
         <oboInOwl:hasRelatedSynonym>Poisonings</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>intoxication</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>poisoning syndrome</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0029000</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">poisoning</rdfs:label>
     </owl:Class>
     
@@ -2200,16 +1717,10 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000011">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
-        <obo:IAO_0000111>planned process</obo:IAO_0000111>
         <obo:IAO_0000112>Injecting mice with a vaccine in order to test its efficacy</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A process that realizes a plan which is the concretization of a plan specification.</obo:IAO_0000115>
-        <obo:IAO_0000116>&apos;Plan&apos; includes a future direction sense. That can be problematic if plans are changed during their execution. There are however implicit contingencies for protocols that an agent has in his mind that can be considered part of the plan, even if the agent didn&apos;t have them in mind before. Therefore, a planned process can diverge from what the agent would have said the plan was before executing it, by adjusting to problems encountered during execution (e.g. choosing another reagent with equivalent properties, if the originally planned one has run out.)</obo:IAO_0000116>
-        <obo:IAO_0000116>We are only considering successfully completed planned processes. A plan may be modified, and details added during execution. For a given planned process, the associated realized plan specification is the one encompassing all changes made during execution. This means that all processes in which an agent acts towards achieving some 
-objectives is a planned process.</obo:IAO_0000116>
-        <obo:IAO_0000117>Bjoern Peters</obo:IAO_0000117>
         <obo:IAO_0000119>branch derived</obo:IAO_0000119>
-        <obo:IAO_0000232>6/11/9: Edited at workshop. Used to include: is initiated by an agent</obo:IAO_0000232>
-        <rdfs:label>planned process</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">planned process</rdfs:label>
     </owl:Class>
     
 
@@ -2218,16 +1729,11 @@ objectives is a planned process.</obo:IAO_0000116>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000070">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000011"/>
-        <obo:IAO_0000111 xml:lang="en">assay</obo:IAO_0000111>
         <obo:IAO_0000112>Assay the wavelength of light emitted by excited Neon atoms. Count of geese flying over a house.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A planned process with the objective to produce information about the material entity that is the evaluant, by physically examining it or its proxies.</obo:IAO_0000115>
-        <obo:IAO_0000116>12/3/12: BP: the reference to the &apos;physical examination&apos; is included to point out that a prediction is not an assay, as that does not require physical examiniation.</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">PlanAndPlannedProcess Branch</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">measuring</obo:IAO_0000118>
         <obo:IAO_0000118 xml:lang="en">scientific observation</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">OBI branch derived</obo:IAO_0000119>
-        <obo:OBI_0001847>study assay</obo:OBI_0001847>
-        <obo:OBI_9991118>any method</obo:OBI_9991118>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">assay</rdfs:label>
     </owl:Class>
     
@@ -2237,16 +1743,11 @@ objectives is a planned process.</obo:IAO_0000116>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000094">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000011"/>
-        <obo:IAO_0000111>material processing</obo:IAO_0000111>
         <obo:IAO_0000112>A cell lysis, production of a cloning vector, creating a buffer.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A planned process which results in physical changes in a specified input material</obo:IAO_0000115>
-        <obo:IAO_0000117>PERSON: Frank Gibson</obo:IAO_0000117>
-        <obo:IAO_0000117>PERSON: Jennifer Fostel</obo:IAO_0000117>
-        <obo:IAO_0000117>PERSON: Melanie Courtot</obo:IAO_0000117>
-        <obo:IAO_0000117>PERSON: Philippe Rocca Serra</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">material transformation</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">OBI branch derived</obo:IAO_0000119>
-        <rdfs:label>material processing</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">material processing</rdfs:label>
     </owl:Class>
     
 
@@ -2257,14 +1758,12 @@ objectives is a planned process.</obo:IAO_0000116>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000032"/>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">genomics</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DNA/Genotyping</obo:GECKO_9000001>
-        <obo:IAO_0000111>genotyping assay</obo:IAO_0000111>
         <obo:IAO_0000112>High-throughput genotyping of oncogenic human papilloma viruses with MALDI-TOF mass spectrometry. Clin Chem. 2008 Jan;54(1):86-92. Epub 2007 Nov 2.PMID: 17981923</obo:IAO_0000112>
         <obo:IAO_0000115>An assay which generates data about a genotype from a specimen of genomic DNA. A variety of techniques and instruments can be used to produce information about sequence variation at particular genomic positions.</obo:IAO_0000115>
-        <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000118>SNP analysis</obo:IAO_0000118>
         <obo:IAO_0000118>genotype profiling</obo:IAO_0000118>
         <obo:IAO_0000119>OBI Biomaterial</obo:IAO_0000119>
-        <rdfs:label>genotyping assay</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">genotyping assay</rdfs:label>
     </owl:Class>
     
 
@@ -2275,12 +1774,10 @@ objectives is a planned process.</obo:IAO_0000116>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000032"/>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">genomics</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sequence variants (CNV, SNP arrays)</obo:GECKO_9000001>
-        <obo:IAO_0000111>copy number variation profiling assay</obo:IAO_0000111>
         <obo:IAO_0000112>Profiling of copy number variations (CNVs) in healthy individuals from three ethnic groups using a human genome 32 K BAC-clone-based array. PMID:18058796</obo:IAO_0000112>
         <obo:IAO_0000115>An assay that determines lost or amplified genomic regions of DNA by comparing genomic DNA originating from tissues from the same or different individuals using specific techniques such as CGH, array CGH, SNP genotyping</obo:IAO_0000115>
-        <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000118>CNV analysis</obo:IAO_0000118>
-        <rdfs:label>copy number variation profiling assay</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">copy number variation profiling assay</rdfs:label>
     </owl:Class>
     
 
@@ -2291,12 +1788,10 @@ objectives is a planned process.</obo:IAO_0000116>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000032"/>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">genomics</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RNAseq/gene expression</obo:GECKO_9000001>
-        <obo:IAO_0000111>RNA-seq assay</obo:IAO_0000111>
         <obo:IAO_0000115>An transcription profiling assay that determines an RNA sequence by analyzing the transcibed regions of the genome and or to quantitate transcript abundance.</obo:IAO_0000115>
-        <obo:IAO_0000117>James Malone</obo:IAO_0000117>
         <obo:IAO_0000118>transcription profiling by high throughput sequencing</obo:IAO_0000118>
         <obo:IAO_0000119>EFO:0002770</obo:IAO_0000119>
-        <rdfs:label>RNA-seq assay</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RNA-seq assay</rdfs:label>
     </owl:Class>
     
 
@@ -2307,12 +1802,9 @@ objectives is a planned process.</obo:IAO_0000116>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000070"/>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">laboratory measures</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">microbiology</obo:GECKO_9000001>
-        <obo:IAO_0000111>organism identification assay</obo:IAO_0000111>
         <obo:IAO_0000115>An assay that identifies the organism species in a specimen.</obo:IAO_0000115>
-        <obo:IAO_0000117>Chris Stoeckert</obo:IAO_0000117>
-        <obo:IAO_0000117>Jie Zheng</obo:IAO_0000117>
         <obo:IAO_0000119>NIAID GSCID-BRC metadata working group</obo:IAO_0000119>
-        <rdfs:label>organism identification assay</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">organism identification assay</rdfs:label>
     </owl:Class>
     
 
@@ -2323,12 +1815,9 @@ objectives is a planned process.</obo:IAO_0000116>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000032"/>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">genomics</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Epigenetics</obo:GECKO_9000001>
-        <obo:IAO_0000111>epigenetic modification assay</obo:IAO_0000111>
         <obo:IAO_0000115>An assay that identifies epigenetic modifications including histone modifications, open chromatin, and DNA methylation.</obo:IAO_0000115>
-        <obo:IAO_0000117>Chris Stoeckert</obo:IAO_0000117>
-        <obo:IAO_0000117>Jie Zheng</obo:IAO_0000117>
         <obo:IAO_0000119>Penn group</obo:IAO_0000119>
-        <rdfs:label>epigenetic modification assay</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">epigenetic modification assay</rdfs:label>
     </owl:Class>
     
 
@@ -2339,15 +1828,12 @@ objectives is a planned process.</obo:IAO_0000116>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000032"/>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">genomics</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">WGS</obo:GECKO_9000001>
-        <obo:IAO_0000111>whole genome sequencing assay</obo:IAO_0000111>
         <obo:IAO_0000112>WGS permits comprehensive sequencing of introns and exons, whereas whole exome sequencing (WES) allows deeper sequencing of exonic regions at a lower cost. Due to the large number of genetic variants found in each genome, it is necessary to use filtering approaches to distinguish deleterious from benign variants. WES has been used successfully to identify novel genetic causes of primary immunodeficiency. Complex structural variations and non-Mendelian disorders remain challenges for WGS.</obo:IAO_0000112>
         <obo:IAO_0000115>A DNA sequencing assay that intends to provide information about the sequence of an entire genome of an organism.</obo:IAO_0000115>
-        <obo:IAO_0000116>Genotyping assays should ideally identify which part of the genome the information is about. We do not currently have a good way to do this. That information should be added later.</obo:IAO_0000116>
-        <obo:IAO_0000117>ImmPort</obo:IAO_0000117>
         <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">WGS</obo:IAO_0000118>
         <obo:IAO_0000119>PMID:23095910</obo:IAO_0000119>
         <obo:IAO_0000119>PMID:25827230</obo:IAO_0000119>
-        <rdfs:label>whole genome sequencing assay</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">whole genome sequencing assay</rdfs:label>
     </owl:Class>
     
 
@@ -2358,13 +1844,11 @@ objectives is a planned process.</obo:IAO_0000116>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000032"/>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">genomics</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">WES</obo:GECKO_9000001>
-        <obo:IAO_0000111>exome sequencing assay</obo:IAO_0000111>
         <obo:IAO_0000112>DNA was extracted from the Ficoll pellet of blood taken from congenital asplenia patients. Unamplified, high-molecular weight, RNase-treated genomic DNA (4_6 _g) was used for whole exome sequencing (WES) with the use of Agilent 71 Mb (V4 + UTR) singlesample capture and an Illumina HiSeq 2000. Sequencing was carried out so as to obtain 30_ coverage from 2 _ 100-bp paired-end reads. We used the Annovar tool (25) to annotate the resulting highquality (HQ) variants. In the regions targeted by WES capture (81.5% of the consensus coding genome), the mean numbers of single-nucleotide variants (SNVs) and small insertions/deletions (indels) detected per sample were 84,192 and13,325, respectively. After filtering, a mean of 74,398 (95.3%) high-quality (HQ) SNVs and 9,033 (70.6%) HQ indels were called. A mean of 105 coding HQ SNVs and 32 indels was identified.</obo:IAO_0000112>
         <obo:IAO_0000115>A DNA sequencing assay that intends to provide information about the sequence of the protein coding components of a genome (exons).</obo:IAO_0000115>
-        <obo:IAO_0000117>ImmPort</obo:IAO_0000117>
         <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">WES</obo:IAO_0000118>
         <obo:IAO_0000119>PMID:25827230</obo:IAO_0000119>
-        <rdfs:label>exome sequencing assay</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exome sequencing assay</rdfs:label>
     </owl:Class>
     
 
@@ -2375,12 +1859,9 @@ objectives is a planned process.</obo:IAO_0000116>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">physical environment</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to carcinogens</obo:GECKO_9000001>
-        <obo:IAO_0000111>exposure to environmental and workplace carcinogens history</obo:IAO_0000111>
         <obo:IAO_0000115>A information content entity that indicates the exposure of an individual to carcinogens in the workplace or environment.</obo:IAO_0000115>
-        <obo:IAO_0000117>Chris Stoeckert, Helena Ellis</obo:IAO_0000117>
         <obo:IAO_0000119>OBIB</obo:IAO_0000119>
-        <obo:IAO_0000234>NCI BBRB</obo:IAO_0000234>
-        <rdfs:label>exposure to environmental and workplace carcinogens history</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to environmental and workplace carcinogens history</rdfs:label>
     </owl:Class>
     
 
@@ -2391,15 +1872,11 @@ objectives is a planned process.</obo:IAO_0000116>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000032"/>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">genomics</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Metagenomics</obo:GECKO_9000001>
-        <obo:IAO_0000111>whole metagenome sequencing assay</obo:IAO_0000111>
         <obo:IAO_0000115>A DNA sequencing assay that intends to provide information on the DNA sequences of multiple genomes (a metagenome) from different organisms present in the same input sample.</obo:IAO_0000115>
-        <obo:IAO_0000116>Whole metagenome sequencing has been used to explore the composition and metabolic capability of communities of microbes found in the environment (e.g. in soil, water, etc.) and in humans and other species (e.g. in the gut, oral cavity, etc.).</obo:IAO_0000116>
-        <obo:IAO_0000117>Rebecca Jackson</obo:IAO_0000117>
         <obo:IAO_0000118>WMS</obo:IAO_0000118>
         <obo:IAO_0000119>Bjoern Peters</obo:IAO_0000119>
         <obo:IAO_0000119>Michelle Giglio</obo:IAO_0000119>
-        <obo:IAO_0000233>https://github.com/obi-ontology/obi/issues/1056</obo:IAO_0000233>
-        <rdfs:label>whole metagenome sequencing assay</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">whole metagenome sequencing assay</rdfs:label>
     </owl:Class>
     
 
@@ -2408,12 +1885,10 @@ objectives is a planned process.</obo:IAO_0000116>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0302893">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000011"/>
-        <obo:IAO_0000111>storage</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">PMID: 18550121.Total Prostate Specific Antigen Stability Confirmed After Long-Term Storage of Serum at -80C. J Urol. 2008 Jun 10.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A maintenance process by which material entities that are not actively metabolizing are placed in well identified location and possibly under controlled environment in ad-hoc devices/structures in order to preserve and protect them from decay/alteration and maintain availability</obo:IAO_0000115>
-        <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000119>OBI-Branch</obo:IAO_0000119>
-        <rdfs:label>storage</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">storage</rdfs:label>
     </owl:Class>
     
 
@@ -2424,13 +1899,9 @@ objectives is a planned process.</obo:IAO_0000116>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000104"/>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">basic cohort attributes</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">study design</obo:GECKO_9000001>
-        <obo:IAO_0000111 xml:lang="en">study design</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">a matched pairs study design describes criteria by which subjects are identified as pairs which then undergo the same protocols, and the data generated is analyzed by comparing the differences between the paired subjects, which constitute the results of the executed study design.</obo:IAO_0000112>
         <obo:IAO_0000115>A plan specification comprised of protocols (which may specify how and what kinds of data will be gathered) that are executed as part of an investigation and is realized during a study design execution.</obo:IAO_0000115>
-        <obo:IAO_0000116>Editor note: there is at least an implicit restriction on the kind of data transformations that can be done based on the measured data available.</obo:IAO_0000116>
-        <obo:IAO_0000117>PERSON: Chris Stoeckert</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">experimental design</obo:IAO_0000118>
-        <obo:IAO_0000232 xml:lang="en">rediscussed at length (MC/JF/BP). 12/9/08). The definition was clarified to differentiate it from protocol.</obo:IAO_0000232>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">study design</rdfs:label>
     </owl:Class>
     
@@ -2442,10 +1913,8 @@ objectives is a planned process.</obo:IAO_0000116>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000033"/>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">population data</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">criteria for enrollment and recruitment procedures</obo:GECKO_9000001>
-        <obo:IAO_0000111 xml:lang="en">inclusion criterion</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">PMID: 23979341-The major inclusion criterion was patients in whom severe cerebral embolism was diagnosed at age 75 or younger (more than 9 in the NIHSS score on day 7 after the onset of stroke) .</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">an inclusion criterion (rule) is_a *eligibility criterion*  which defines and states a condition which, if met, makes an entity suitable for a given task or participation in a given process. For instance, in a study protocol, inclusion criteria indicate the conditions that prospective subjects MUST meet to be eligible for participation in a study.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Person: Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">inclusion condition</obo:IAO_0000118>
         <obo:IAO_0000118 xml:lang="en">inclusion rule</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">Adapted from Clinical Research Glossary Version 4.0 CDICS glossary group</obo:IAO_0000119>
@@ -2459,9 +1928,7 @@ objectives is a planned process.</obo:IAO_0000116>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OGMS_0000015">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
         <obo:IAO_0000115 xml:lang="en">A series of statements representing health-relevant qualities of a patient and of a patient&apos;s family.</obo:IAO_0000115>
-        <obo:IAO_0000117>Albert Goldfain</obo:IAO_0000117>
         <obo:IAO_0000119>http://ontology.buffalo.edu/medo/Disease_and_Diagnosis.pdf</obo:IAO_0000119>
-        <obo:IAO_0000232>creation date: 2010-07-19T10:18:59Z</obo:IAO_0000232>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">clinical history</rdfs:label>
     </owl:Class>
     
@@ -2474,10 +1941,7 @@ objectives is a planned process.</obo:IAO_0000116>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">other questionnaire/survey data</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">signs and symptoms</obo:GECKO_9000001>
         <obo:IAO_0000115 xml:lang="en">A process experienced by the patient, which can only be experienced by the patient, that is hypothesized to be clinically relevant.</obo:IAO_0000115>
-        <obo:IAO_0000116>note: defined class</obo:IAO_0000116>
         <obo:IAO_0000119>http://ontology.buffalo.edu/medo/Disease_and_Diagnosis.pdf</obo:IAO_0000119>
-        <obo:IAO_0000232>creation date: 2010-11-18T11:02:10Z
-Updated: 2020-07-06</obo:IAO_0000232>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">symptom</rdfs:label>
     </owl:Class>
     
@@ -2501,8 +1965,6 @@ Updated: 2020-07-06</obo:IAO_0000232>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">socio-demographic and economic characteristics</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">age/birthdate</obo:GECKO_9000001>
         <obo:IAO_0000115>A time quality inhering in a bearer by virtue of how long the bearer has existed.</obo:IAO_0000115>
-        <oboInOwl:hasOBONamespace>quality</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>PATO:0000011</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">age</rdfs:label>
     </owl:Class>
     
@@ -2515,8 +1977,6 @@ Updated: 2020-07-06</obo:IAO_0000232>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">socio-demographic and economic characteristics</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biological sex</obo:GECKO_9000001>
         <obo:IAO_0000115>An organismal quality inhering in a bearer by virtue of the bearer&apos;s ability to undergo sexual reproduction in order to differentiate the individuals or types involved.</obo:IAO_0000115>
-        <oboInOwl:hasOBONamespace>quality</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>PATO:0000047</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biological sex</rdfs:label>
     </owl:Class>
     
@@ -2529,8 +1989,6 @@ Updated: 2020-07-06</obo:IAO_0000232>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">questionnaire/survey data</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">socio-demographic and economic characteristics</obo:GECKO_9000001>
         <obo:IAO_0000115>A quality that inheres in an entire organism or part of an organism.</obo:IAO_0000115>
-        <oboInOwl:hasOBONamespace>quality</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>PATO:0001995</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">organismal quality</rdfs:label>
     </owl:Class>
     
@@ -2569,7 +2027,6 @@ Updated: 2020-07-06</obo:IAO_0000232>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000033"/>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">medication</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">administration</obo:GECKO_9000001>
-        <obo:IAO_0000111 xml:lang="en">prescribed drug administration specification</obo:IAO_0000111>
         <obo:IAO_0000112>&apos;take Aspirin 81 mg oral tablet, 1 tablet once daily by mouth, start today&apos; or the synonymous abbreviated version &apos;Aspirin 81 mg tablet PO DIE&apos;</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A drug administration description that specifies a drug administration prescribed or reported by an healthcare provider.
 
@@ -2589,9 +2046,7 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000109"/>
         <obo:IAO_0000112 xml:lang="en"></obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">a statistic is a measurement datum to describe a dataset or a variable. It is generated by a calculation on set of observed data.</obo:IAO_0000115>
-        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">STATO, adapted from wikipedia (http://en.wikipedia.org/wiki/Statistic).</obo:IAO_0000119>
-        <obo:STATO_0000032 xml:lang="en">statistic</obo:STATO_0000032>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">statistic</rdfs:label>
     </owl:Class>
     
@@ -2603,9 +2058,7 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000109"/>
         <obo:IAO_0000112 xml:lang="en">a count of 4 resulting from counting limbs in humans</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">a count is a data item denoted by an integer and represented the number of instances or occurences of an entity</obo:IAO_0000115>
-        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">STATO</obo:IAO_0000119>
-        <obo:STATO_0000032 xml:lang="en"></obo:STATO_0000032>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">count</rdfs:label>
     </owl:Class>
     
@@ -2618,9 +2071,6 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">survey administration</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">date and time-related information</obo:GECKO_9000001>
         <obo:IAO_0000115 xml:lang="en">Information about a calendar date or timestamp indicating day, month, year and time of an event.</obo:IAO_0000115>
-        <obo:IAO_0000117>Alejandra Gonzalez-Beltran</obo:IAO_0000117>
-        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
-        <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">STATO</obo:IAO_0000119>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">date</rdfs:label>
     </owl:Class>
@@ -2634,26 +2084,8 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">other questionnaire/survey data</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">life stage/time point</obo:GECKO_9000001>
         <obo:IAO_0000115>A spatiotemporal region encompassing some part of the life cycle of an organism.</obo:IAO_0000115>
-        <obo:IAO_0000116>this class represents a proper part of the life cycle of an organism. The class &apos;life cycle&apos; should not be placed here</obo:IAO_0000116>
-        <obo:UBPROP_0000012>the WBls class &apos;all stages&apos; belongs here as it is the superclass of other WBls stages</obo:UBPROP_0000012>
-        <obo:UBPROP_0000012>we map the ZFS unknown stage here as it is logically equivalent to saying *some* life cycle stage</obo:UBPROP_0000012>
-        <oboInOwl:hasDbXref>BILS:0000105</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000399</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>FBdv:00007012</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>FMA:24120</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>HsapDv:0000000</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MmusDv:0000000</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>OlatDv:0000010</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>PdumDv:0000090</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>WBls:0000002</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>XAO:1000000</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ZFS:0000000</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ZFS:0100000</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ncithesaurus:Developmental_Stage</oboInOwl:hasDbXref>
         <oboInOwl:hasNarrowSynonym>developmental stage</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasNarrowSynonym>stage</oboInOwl:hasNarrowSynonym>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>UBERON:0000105</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">life cycle stage</rdfs:label>
     </owl:Class>
     
@@ -2666,38 +2098,9 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sample type</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">blood</obo:GECKO_9000001>
         <obo:IAO_0000115>A fluid that is composed of blood plasma and erythrocytes.</obo:IAO_0000115>
-        <obo:IAO_0000232>This class excludes blood analogues, such as the insect analog of blood. See UBERON:0000179 haemolymphatic fluid.</obo:IAO_0000232>
-        <obo:UBPROP_0000001>A complex mixture of cells suspended in a liquid matrix that delivers nutrients to cells and removes wastes. (Source: BioGlossary, www.Biology-Text.com)[TAO]</obo:UBPROP_0000001>
-        <obo:UBPROP_0000001>Highly specialized circulating tissue consisting of several types of cells suspended in a fluid medium known as plasma.[AAO]</obo:UBPROP_0000001>
-        <obo:UBPROP_0000002>relationship loss: subclass specialized connective tissue (AAO:0000571)[AAO]</obo:UBPROP_0000002>
-        <obo:UBPROP_0000003>Recent findings strongly suggest that the molecular pathways involved in the development and function of blood cells are highly conserved among vertebrates and various invertebrates phyla. (...) There is now good reason to believe that, in vertebrates and invertebrates alike, blood cell lineages diverge from a common type of progenitor cell, the hemocytoblast.[well established][VHOG]</obo:UBPROP_0000003>
-        <oboInOwl:hasDbXref>AAO:0000046</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>BTO:0000089</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>CALOHA:TS-0079</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000296</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EHDAA2:0000176</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EHDAA:418</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EMAPA:16332</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ENVO:02000027</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EV:0100047</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>FMA:9670</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>GAID:965</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MA:0000059</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D001769</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MIAA:0000315</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C12434</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>OpenCyc:Mx4rvVjI8JwpEbGdrcN5Y29ycA</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>TAO:0000007</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0005767</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>VHOG:0000224</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>XAO:0000124</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ZFA:0000007</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>galen:Blood</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>portion of blood</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>vertebrate blood</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
         <oboInOwl:hasRelatedSynonym>whole blood</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>UBERON:0000178</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">blood</rdfs:label>
     </owl:Class>
     
@@ -2710,32 +2113,11 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biosample</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sample type</obo:GECKO_9000001>
         <obo:IAO_0000115>Material anatomical entity in a gaseous, liquid, semisolid or solid state; produced by anatomical structures or derived from inhaled and ingested substances that have been modified by anatomical structures as they pass through the body.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>AAO:0010839</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>AEO:0000004</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>BILA:0000004</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>CALOHA:TS-2101</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>CARO:0000004</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EHDAA2:0003004</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EMAPA:35178</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>FBbt:00007019</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>FMA:9669</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>HAO:0000004</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MA:0002450</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C13236</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SPD:0000008</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>TAO:0001487</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>TGMA:0001824</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>VHOG:0001726</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>XAO:0004001</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ZFA:0001487</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>galen:BodySubstance</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>body fluid or substance</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>body substance</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>organism substance</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>portion of body substance</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>portion of organism substance</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>UBERON:0000463</oboInOwl:id>
         <rdfs:label>organism substance</rdfs:label>
     </owl:Class>
     
@@ -2748,24 +2130,6 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sample type</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">urine</obo:GECKO_9000001>
         <obo:IAO_0000115>Excretion that is the output of a kidney</obo:IAO_0000115>
-        <obo:UBPROP_0000008>kidney excreta from some taxa (e.g. in aves) may not be liquid</obo:UBPROP_0000008>
-        <oboInOwl:hasDbXref>BTO:0001419</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>CALOHA:TS-1092</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0001939</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EMAPA:36554</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ENVO:00002047</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>FMA:12274</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>GAID:1189</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MA:0002545</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MAT:0000058</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D014556</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MIAA:0000058</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C13283</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>OpenCyc:Mx4rvVjGppwpEbGdrcN5Y29ycA</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0042036</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>galen:Urine</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>UBERON:0001088</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">urine</rdfs:label>
     </owl:Class>
     
@@ -2778,27 +2142,10 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sample type</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">saliva</obo:GECKO_9000001>
         <obo:IAO_0000115>A fluid produced in the oral cavity by salivary glands, typically used in predigestion, but also in other functions.</obo:IAO_0000115>
-        <obo:UBPROP_0000007>salivary</obo:UBPROP_0000007>
-        <obo:UBPROP_0000008>We classify a wide variety of not necessarily homologous fluids here. In humans, the saliva is a turbid and slightly viscous fluid, generally of an alkaline reaction, and is secreted by the parotid, submaxillary, and sublingual glands. In the mouth the saliva is mixed with the secretion from the buccal glands. In man and many animals, saliva is an important digestive fluid on account of the presence of the peculiar enzyme, ptyalin</obo:UBPROP_0000008>
-        <oboInOwl:hasDbXref>BTO:0001202</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>CALOHA:TS-0891</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EMAPA:36536</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ENVO:02000036</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>FMA:59862</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>GAID:1167</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MA:0002507</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MAT:0000444</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D012463</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C13275</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>OpenCyc:Mx4rvVjJ95wpEbGdrcN5Y29ycA</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0036087</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>galen:Saliva</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>salivary gland secretion</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
         <oboInOwl:hasRelatedSynonym>sailva normalis</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>saliva atomaris</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>saliva molecularis</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>UBERON:0001836</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">saliva</rdfs:label>
     </owl:Class>
     
@@ -2811,22 +2158,7 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sample type</obo:GECKO_9000000>
         <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stool</obo:GECKO_9000001>
         <obo:IAO_0000115>Portion of semisolid bodily waste discharged through the anus[MW,modified]</obo:IAO_0000115>
-        <obo:UBPROP_0000001>Excretion in semisolid state processed by the intestine.[FMA]</obo:UBPROP_0000001>
-        <obo:UBPROP_0000007>fecal</obo:UBPROP_0000007>
         <oboInOwl:hasBroadSynonym>excreta</oboInOwl:hasBroadSynonym>
-        <oboInOwl:hasDbXref>BTO:0000440</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>CALOHA:TS-2345</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ENVO:00002003</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>FMA:64183</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>GAID:1199</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MA:0002509</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MAT:0000053</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D005243</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MIAA:0000053</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C13234</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>OpenCyc:Mx4rvVjJMZwpEbGdrcN5Y29ycA</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0015733</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>galen:Feces</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>faeces</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>fecal material</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>fecal matter</oboInOwl:hasExactSynonym>
@@ -2854,12 +2186,10 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
         <oboInOwl:hasNarrowSynonym>portion of scat</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasNarrowSynonym>scat</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasNarrowSynonym>spraint</oboInOwl:hasNarrowSynonym>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
         <oboInOwl:hasRelatedSynonym>droppings</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>excrement</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>ordure</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>spoor</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>UBERON:0001988</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">feces</rdfs:label>
     </owl:Class>
 </rdf:RDF>

--- a/src/ontology/annotations.owl
+++ b/src/ontology/annotations.owl
@@ -127,6 +127,14 @@
     
 
 
+    <!-- http://www.w3.org/2000/01/rdf-schema#seeAlso -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#seeAlso">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">see also</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -706,6 +714,7 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasRelatedSynonym>disorder of hematopoietic system</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>hematological disorders and malignancies</oboInOwl:hasRelatedSynonym>
         <rdfs:comment>placeholder for lymphoid disease</rdfs:comment>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/monarch-initiative/mondo/issues/254</rdfs:seeAlso>
     </owl:Class>
     
 

--- a/src/ontology/annotations.owl
+++ b/src/ontology/annotations.owl
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="http://purl.obolibrary.org/obo/cob/annotations.owl#"
      xml:base="http://purl.obolibrary.org/obo/cob/annotations.owl"
-     xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -24,18 +23,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/BFO_0000179 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000179"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000180 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000180"/>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/GECKO_9000000 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/GECKO_9000000">
@@ -48,14 +35,6 @@
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/GECKO_9000001">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IHCC browser label</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000111 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000111">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">editor preferred term</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -76,22 +55,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000116 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">editor note</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000117 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000117">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">term editor</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/IAO_0000118 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000118">
@@ -105,132 +68,6 @@
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000119">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">definition source</rdfs:label>
     </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000232 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000232">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">curator note</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000233 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000233">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">term tracker item</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000234 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000234">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ontology term requester</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000600 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000600"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000601 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000601"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000602 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000602"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0001847 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0001847"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_9991118 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OBI_9991118"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/STATO_0000032 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/STATO_0000032"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000001 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000001">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">external_definition</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000002 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000002">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">axiom_lost_from_external_ontology</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000003 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000003">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">homology_notes</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000007 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000007">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_relational_adjective</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000008 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000008">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">taxon_notes</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000012 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000012">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">external_ontology_notes</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.org/dc/elements/1.1/source -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/source"/>
-    
-
-
-    <!-- http://www.geneontology.org/formats/oboInOwl#created_by -->
-
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#created_by"/>
-    
-
-
-    <!-- http://www.geneontology.org/formats/oboInOwl#creation_date -->
-
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#creation_date"/>
     
 
 
@@ -250,12 +87,6 @@
     
 
 
-    <!-- http://www.geneontology.org/formats/oboInOwl#hasDbXref -->
-
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
-    
-
-
     <!-- http://www.geneontology.org/formats/oboInOwl#hasExactSynonym -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym">
@@ -272,34 +103,10 @@
     
 
 
-    <!-- http://www.geneontology.org/formats/oboInOwl#hasOBONamespace -->
-
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasOBONamespace">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_obo_namespace</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
     <!-- http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_related_synonym</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://www.geneontology.org/formats/oboInOwl#id -->
-
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#id">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">id</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://www.geneontology.org/formats/oboInOwl#inSubset -->
-
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#inSubset">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">in_subset</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -316,14 +123,6 @@
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">label</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://www.w3.org/2000/01/rdf-schema#seeAlso -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#seeAlso">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">see also</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -377,8 +176,6 @@
     <!-- http://purl.obolibrary.org/obo/BFO_0000015 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000015">
-        <obo:BFO_0000179>process</obo:BFO_0000179>
-        <obo:BFO_0000180>Process</obo:BFO_0000180>
         <obo:IAO_0000112 xml:lang="en">a process of cell-division, \ a beating of the heart</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">a process of meiosis</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">a process of sleeping</obo:IAO_0000112>
@@ -387,8 +184,6 @@
         <obo:IAO_0000112 xml:lang="en">the life of an organism</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">your process of aging.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">p is a process = Def. p is an occurrent that has temporal proper parts and for some time t, p s-depends_on some material entity at t. (axiom label in BFO2 Reference: [083-003])</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: The realm of occurrents is less pervasively marked by the presence of natural units than is the case in the realm of independent continuants. Thus there is here no counterpart of ‘object’. In BFO 1.0 ‘process’ served as such a counterpart. In BFO 2.0 ‘process’ is, rather, the occurrent counterpart of ‘material entity’. Those natural – as contrasted with engineered, which here means: deliberately executed – units which do exist in the realm of occurrents are typically either parasitic on the existence of natural units on the continuant side, or they are fiat in nature. Thus we can count lives; we can count football games; we can count chemical reactions performed in experiments or in chemical manufacturing. We cannot count the processes taking place, for instance, in an episode of insect mating behavior.Even where natural units are identifiable, for example cycles in a cyclical process such as the beating of a heart or an organism’s sleep/wake cycle, the processes in question form a sequence with no discontinuities (temporal gaps) of the sort that we find for instance where billiard balls or zebrafish or planets are separated by clear spatial gaps. Lives of organisms are process units, but they too unfold in a continuous series from other, prior processes such as fertilization, and they unfold in turn in continuous series of post-life processes such as post-mortem decay. Clear examples of boundaries of processes are almost always of the fiat sort (midnight, a time of death as declared in an operating theater or on a death certificate, the initiation of a state of war)</obo:IAO_0000116>
-        <obo:IAO_0000602>(iff (Process a) (and (Occurrent a) (exists (b) (properTemporalPartOf b a)) (exists (c t) (and (MaterialEntity c) (specificallyDependsOnAt a c t))))) // axiom label in BFO2 CLIF: [083-003]</obo:IAO_0000602>
     </owl:Class>
     
 
@@ -396,17 +191,10 @@
     <!-- http://purl.obolibrary.org/obo/BFO_0000016 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000016">
-        <obo:BFO_0000179>disposition</obo:BFO_0000179>
-        <obo:BFO_0000180>Disposition</obo:BFO_0000180>
         <obo:IAO_0000112 xml:lang="en">an atom of element X has the disposition to decay to an atom of element Y</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">certain people have a predisposition to colon cancer</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">children are innately disposed to categorize objects in certain ways.</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the cell wall is disposed to filter chemicals in endocytosis and exocytosis</obo:IAO_0000112>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Dispositions exist along a strength continuum. Weaker forms of disposition are realized in only a fraction of triggering cases. These forms occur in a significant number of cases of a similar type.</obo:IAO_0000116>
-        <obo:IAO_0000600 xml:lang="en">b is a disposition means: b is a realizable entity &amp; b’s bearer is some material entity &amp; b is such that if it ceases to exist, then its bearer is physically changed, &amp; b’s realization occurs when and because this bearer is in some special physical circumstances, &amp; this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])</obo:IAO_0000600>
-        <obo:IAO_0000601 xml:lang="en">If b is a realizable entity then for all t at which b exists, b s-depends_on some material entity at t. (axiom label in BFO2 Reference: [063-002])</obo:IAO_0000601>
-        <obo:IAO_0000602>(forall (x t) (if (and (RealizableEntity x) (existsAt x t)) (exists (y) (and (MaterialEntity y) (specificallyDepends x y t))))) // axiom label in BFO2 CLIF: [063-002]</obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (Disposition x) (and (RealizableEntity x) (exists (y) (and (MaterialEntity y) (bearerOfAt x y t)))))) // axiom label in BFO2 CLIF: [062-002]</obo:IAO_0000602>
     </owl:Class>
     
 
@@ -414,17 +202,11 @@
     <!-- http://purl.obolibrary.org/obo/BFO_0000017 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000017">
-        <obo:BFO_0000179>realizable</obo:BFO_0000179>
-        <obo:BFO_0000180>RealizableEntity</obo:BFO_0000180>
         <obo:IAO_0000112 xml:lang="en">the disposition of this piece of metal to conduct electricity.</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the disposition of your blood to coagulate</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the function of your reproductive organs</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the role of being a doctor</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the role of this boundary to delineate where Utah and Colorado meet</obo:IAO_0000112>
-        <obo:IAO_0000600 xml:lang="en">To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])</obo:IAO_0000600>
-        <obo:IAO_0000601 xml:lang="en">All realizable dependent continuants have independent continuants that are not spatial regions as their bearers. (axiom label in BFO2 Reference: [060-002])</obo:IAO_0000601>
-        <obo:IAO_0000602>(forall (x t) (if (RealizableEntity x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (bearerOfAt y x t))))) // axiom label in BFO2 CLIF: [060-002]</obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (RealizableEntity x) (and (SpecificallyDependentContinuant x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (inheresIn x y)))))) // axiom label in BFO2 CLIF: [058-002]</obo:IAO_0000602>
     </owl:Class>
     
 
@@ -432,18 +214,12 @@
     <!-- http://purl.obolibrary.org/obo/BFO_0000019 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000019">
-        <obo:BFO_0000179>quality</obo:BFO_0000179>
-        <obo:BFO_0000180>Quality</obo:BFO_0000180>
         <obo:IAO_0000112 xml:lang="en">the ambient temperature of this portion of air</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the color of a tomato</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the length of the circumference of your waist</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the mass of this piece of gold.</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the shape of your nose</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the shape of your nostril</obo:IAO_0000112>
-        <obo:IAO_0000600 xml:lang="en">a quality is a specifically dependent continuant that, in contrast to roles and dispositions, does not require any further process in order to be realized. (axiom label in BFO2 Reference: [055-001])</obo:IAO_0000600>
-        <obo:IAO_0000601 xml:lang="en">If an entity is a quality at any time that it exists, then it is a quality at every time that it exists. (axiom label in BFO2 Reference: [105-001])</obo:IAO_0000601>
-        <obo:IAO_0000602>(forall (x) (if (Quality x) (SpecificallyDependentContinuant x))) // axiom label in BFO2 CLIF: [055-001]</obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (exists (t) (and (existsAt x t) (Quality x))) (forall (t_1) (if (existsAt x t_1) (Quality x))))) // axiom label in BFO2 CLIF: [105-001]</obo:IAO_0000602>
     </owl:Class>
     
 
@@ -451,8 +227,6 @@
     <!-- http://purl.obolibrary.org/obo/BFO_0000029 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000029">
-        <obo:BFO_0000179>site</obo:BFO_0000179>
-        <obo:BFO_0000180>Site</obo:BFO_0000180>
         <obo:IAO_0000112 xml:lang="en">Manhattan Canyon)</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">a hole in the interior of a portion of cheese</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">a rabbit hole</obo:IAO_0000112>
@@ -468,8 +242,6 @@
         <obo:IAO_0000112 xml:lang="en">the interior of your refrigerator</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the lumen of your gut</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">your left nostril (a fiat part – the opening – of your left nasal cavity)</obo:IAO_0000112>
-        <obo:IAO_0000600 xml:lang="en">b is a site means: b is a three-dimensional immaterial entity that is (partially or wholly) bounded by a material entity or it is a three-dimensional immaterial part thereof. (axiom label in BFO2 Reference: [034-002])</obo:IAO_0000600>
-        <obo:IAO_0000602>(forall (x) (if (Site x) (ImmaterialEntity x))) // axiom label in BFO2 CLIF: [034-002]</obo:IAO_0000602>
     </owl:Class>
     
 
@@ -477,8 +249,6 @@
     <!-- http://purl.obolibrary.org/obo/BFO_0000040 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000040">
-        <obo:BFO_0000179>material</obo:BFO_0000179>
-        <obo:BFO_0000180>MaterialEntity</obo:BFO_0000180>
         <obo:IAO_0000112 xml:lang="en">a flame</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">a forest fire</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">a human being</obo:IAO_0000112>
@@ -491,26 +261,13 @@
         <obo:IAO_0000112 xml:lang="en">an energy wave</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">an epidemic</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the undetached arm of a human being</obo:IAO_0000112>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Material entities (continuants) can preserve their identity even while gaining and losing material parts. Continuants are contrasted with occurrents, which unfold themselves in successive temporal parts or phases [60</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Object, Fiat Object Part and Object Aggregate are not intended to be exhaustive of Material Entity. Users are invited to propose new subcategories of Material Entity.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: ‘Matter’ is intended to encompass both mass and energy (we will address the ontological treatment of portions of energy in a later version of BFO). A portion of matter is anything that includes elementary particles among its proper or improper parts: quarks and leptons, including electrons, as the smallest particles thus far discovered; baryons (including protons and neutrons) at a higher level of granularity; atoms and molecules at still higher levels, forming the cells, organs, organisms and other material entities studied by biologists, the portions of rock studied by geologists, the fossils studied by paleontologists, and so on.Material entities are three-dimensional entities (entities extended in three spatial dimensions), as contrasted with the processes in which they participate, which are four-dimensional entities (entities extended also along the dimension of time).According to the FMA, material entities may have immaterial entities as parts – including the entities identified below as sites; for example the interior (or ‘lumen’) of your small intestine is a part of your body. BFO 2.0 embodies a decision to follow the FMA here.</obo:IAO_0000116>
-        <obo:IAO_0000600 xml:lang="en">A material entity is an independent continuant that has some portion of matter as proper or improper continuant part. (axiom label in BFO2 Reference: [019-002])</obo:IAO_0000600>
-        <obo:IAO_0000601 xml:lang="en">Every entity which has a material entity as continuant part is a material entity. (axiom label in BFO2 Reference: [020-002])</obo:IAO_0000601>
-        <obo:IAO_0000601 xml:lang="en">every entity of which a material entity is continuant part is also a material entity. (axiom label in BFO2 Reference: [021-002])</obo:IAO_0000601>
-        <obo:IAO_0000602>(forall (x) (if (MaterialEntity x) (IndependentContinuant x))) // axiom label in BFO2 CLIF: [019-002]</obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (and (Entity x) (exists (y t) (and (MaterialEntity y) (continuantPartOfAt x y t)))) (MaterialEntity x))) // axiom label in BFO2 CLIF: [021-002]</obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (and (Entity x) (exists (y t) (and (MaterialEntity y) (continuantPartOfAt y x t)))) (MaterialEntity x))) // axiom label in BFO2 CLIF: [020-002]</obo:IAO_0000602>
     </owl:Class>
     
 
 
     <!-- http://purl.obolibrary.org/obo/BFO_0000141 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000141">
-        <obo:BFO_0000179>immaterial</obo:BFO_0000179>
-        <obo:BFO_0000180>ImmaterialEntity</obo:BFO_0000180>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Immaterial entities are divided into two subgroups:boundaries and sites, which bound, or are demarcated in relation, to material entities, and which can thus change location, shape and size and as their material hosts move or change shape or size (for example: your nasal passage; the hold of a ship; the boundary of Wales (which moves with the rotation of the Earth) [38, 7, 10</obo:IAO_0000116>
-    </owl:Class>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000141"/>
     
 
 
@@ -518,9 +275,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000147">
         <obo:IAO_0000115>An information content entity indicating the cause of death for a participant in the study.</obo:IAO_0000115>
-        <obo:IAO_0000117>Person:  Jie Zheng, Chris Stoeckert, David Roos, Grant Dorsey</obo:IAO_0000117>
         <obo:IAO_0000119>Penn Group</obo:IAO_0000119>
-        <dc:source>PRISM</dc:source>
     </owl:Class>
     
 
@@ -529,9 +284,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000308">
         <obo:IAO_0000115 xml:lang="en">an information content entity that is about a part of a health care encounter that occurs in a hospital facility</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Person: John Judkins</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">EuPathDB</obo:IAO_0000119>
-        <oboInOwl:inSubset>ICEMR protein array</oboInOwl:inSubset>
     </owl:Class>
     
 
@@ -548,7 +301,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000374">
         <obo:IAO_0000115 xml:lang="en">a categorical value specification that is about a human being and specifies whether that human being is joined to another human being in marriage</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Person: John Judkins</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">EuPathDB, BFO&apos;s &apos;relational quality&apos; examples</obo:IAO_0000119>
     </owl:Class>
     
@@ -566,9 +318,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0010032">
         <obo:IAO_0000115>environmental system associated with the dwelling used by humans.</obo:IAO_0000115>
-        <obo:IAO_0000117>Person:  Cristian Cocos, Jie Zheng, Chris Stoeckert</obo:IAO_0000117>
         <obo:IAO_0000119>Penn Group</obo:IAO_0000119>
-        <dc:source>GEMS</dc:source>
     </owl:Class>
     
 
@@ -577,18 +327,13 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0008150">
         <obo:IAO_0000115>A biological process represents a specific objective that the organism is genetically programmed to achieve. Biological processes are often described by their outcome or ending state, e.g., the biological process of cell division results in the creation of two daughter cells (a divided cell) from a single parent cell. A biological process is accomplished by a particular set of molecular functions carried out by specific gene products (or macromolecular complexes), often in a highly regulated manner and in a particular temporal sequence.</obo:IAO_0000115>
-        <oboInOwl:created_by>jl</oboInOwl:created_by>
-        <oboInOwl:creation_date>2012-09-19T15:05:24Z</oboInOwl:creation_date>
         <oboInOwl:hasAlternativeId>GO:0000004</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>GO:0007582</oboInOwl:hasAlternativeId>
         <oboInOwl:hasAlternativeId>GO:0044699</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref>Wikipedia:Biological_process</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>biological process</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>physiological process</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>biological_process</oboInOwl:hasOBONamespace>
         <oboInOwl:hasRelatedSynonym>single organism process</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>single-organism process</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>GO:0008150</oboInOwl:id>
         <rdfs:comment>Note that, in addition to forming the root of the biological process ontology, this term is recommended for use for the annotation of gene products whose biological process is unknown. When this term is used for annotation, it indicates that no information was available about the biological process of the gene product annotated as of the date the annotation was made; the evidence code &apos;no data&apos; (ND), is used to indicate this.</rdfs:comment>
     </owl:Class>
     
@@ -597,16 +342,8 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000005 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000005">
-        <obo:IAO_0000111 xml:lang="en">objective specification</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">In the protocol of a ChIP assay the objective specification says to identify protein and DNA interaction.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A directive information entity that describes an intended process endpoint. When part of a plan specification the concretization is realized in a planned process in which the bearer tries to effect the world so that the process endpoint is achieved.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">2009-03-16: original definition when imported from OBI read: &quot;objective is an non realizable information entity which can serve as that  proper part of a plan towards which the realization of the plan is directed.&quot;</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">2014-03-31: In the example of usage (&quot;In the protocol of a ChIP assay the objective specification says to identify protein and DNA interaction&quot;) there is a protocol which is the ChIP assay protocol. In addition to being concretized on paper, the protocol can be concretized as a realizable entity, such as a plan that inheres in a person. The objective specification is the part that says that some protein and DNA interactions are identified. This is a specification of a process endpoint: the boundary in the process before which they are not identified and after which they are. During the realization of the plan, the goal is to get to the point of having the interactions, and participants in the realization of the plan try to do that.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">Answers the question, why did you do this experiment?</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Barry Smith</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Bjoern Peters</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Jennifer Fostel</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">goal specification</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">OBI Plan and Planned Process/Roles Branch</obo:IAO_0000119>
         <obo:IAO_0000119 xml:lang="en">OBI_0000217</obo:IAO_0000119>
@@ -617,13 +354,8 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000027 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000027">
-        <obo:IAO_0000111 xml:lang="en">data item</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">Data items include counts of things, analyte concentrations, and statistical summaries.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">An information content entity that is intended to be a truthful statement about something (modulo, e.g., measurement precision or other systematic errors) and is constructed/acquired by a method which reliably tends to produce (approximately) truthful statements.</obo:IAO_0000115>
-        <obo:IAO_0000116>2014-03-31: See discussion at http://odontomachus.wordpress.com/2014/03/30/aboutness-objects-propositions/</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Chris Stoeckert</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Jonathan Rees</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">data</obo:IAO_0000118>
     </owl:Class>
     
@@ -632,14 +364,8 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000030 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000030">
-        <obo:IAO_0000111 xml:lang="en">information content entity</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">Examples of information content entites include journal articles, data, graphical layouts, and graphs.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A generically dependent continuant that is about some thing.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">2014-03-10: The use of &quot;thing&quot; is intended to be general enough to include universals and configurations (see https://groups.google.com/d/msg/information-ontology/GBxvYZCk1oc/-L6B5fSBBTQJ).</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">information_content_entity &apos;is_encoded_in&apos; some digital_entity in obi before split (040907). information_content_entity &apos;is_encoded_in&apos; some physical_document in obi before split (040907).
-
-Previous. An information content entity is a non-realizable information entity that &apos;is encoded in&apos; some digital or physical entity.</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Chris Stoeckert</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">OBI_0000142</obo:IAO_0000119>
     </owl:Class>
     
@@ -649,12 +375,6 @@ Previous. An information content entity is a non-realizable information entity t
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000033">
         <obo:IAO_0000115 xml:lang="en">An information content entity whose concretizations indicate to their bearer how to realize them in a process.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">2009-03-16: provenance: a term realizable information entity was proposed for OBI (OBI_0000337) , edited by the PlanAndPlannedProcess branch. Original definition was  &quot;is the specification of a process that can be concretized and realized by an actor&quot; with alternative term  &quot;instruction&quot;.It has been subsequently moved to IAO where the objective for which the original term was defined was satisfied with the definitionof this, different, term.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">2013-05-30 Alan Ruttenberg: What differentiates a directive information entity from an information concretization is that it can have concretizations that are either qualities or realizable entities. The concretizations that are realizable entities are created when an individual chooses to take up the direction, i.e. has the intention to (try to) realize it.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">8/6/2009 Alan Ruttenberg: Changed label from &quot;information entity about a realizable&quot; after discussions at ICBO</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">Werner pushed back on calling it realizable information entity as it isn&apos;t realizable. However this name isn&apos;t right either. An example would be a recipe. The realizable entity would be a plan, but the information entity isn&apos;t about the plan, it, once concretized, *is* the plan. -Alan</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Bjoern Peters</obo:IAO_0000117>
     </owl:Class>
     
 
@@ -662,13 +382,8 @@ Previous. An information content entity is a non-realizable information entity t
     <!-- http://purl.obolibrary.org/obo/IAO_0000104 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000104">
-        <obo:IAO_0000111 xml:lang="en">plan specification</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">PMID: 18323827.Nat Med. 2008 Mar;14(3):226.New plan proposed to help resolve conflicting medical advice.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A directive information entity with action specifications and objective specifications as parts that, when concretized, is realized in a process in which the bearer tries to achieve the objectives by taking the actions specified.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">2009-03-16: provenance: a term a plan was proposed for OBI (OBI_0000344) , edited by the PlanAndPlannedProcess branch. Original definition was &quot; a plan is a specification of a process that is realized by an actor to achieve the objective specified as part of the plan&quot;. It has been subsequently moved to IAO where the objective for which the original term was defined was satisfied with the definitionof this, different, term.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">2014-03-31: A plan specification can have other parts, such as conditional specifications.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">Alternative previous definition: a plan is a set of instructions that specify how an objective should be achieved</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">OBI Plan and Planned Process branch</obo:IAO_0000119>
         <obo:IAO_0000119 xml:lang="en">OBI_0000344</obo:IAO_0000119>
         <rdfs:comment xml:lang="en">2/3/2009 Comment from OBI review.
@@ -685,11 +400,8 @@ Request that IAO either clarify these or change definitions not to use them</rdf
     <!-- http://purl.obolibrary.org/obo/IAO_0000109 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000109">
-        <obo:IAO_0000111 xml:lang="en">measurement datum</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">Examples of measurement data are the recoding of the weight of a mouse as {40,mass,&quot;grams&quot;}, the recording of an observation of the behavior of the mouse {,process,&quot;agitated&quot;}, the recording of the expression level of a gene as measured through the process of microarray experiment {3.4,luminosity,}.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A measurement datum is an information content entity that is a recording of the output of a measurement such as produced by a device.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">2/2/2009 is_specified_output of some assay?</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">person:Chris Stoeckert</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">OBI_0000305</obo:IAO_0000119>
         <obo:IAO_0000119 xml:lang="en">group:OBI</obo:IAO_0000119>
     </owl:Class>
@@ -699,12 +411,8 @@ Request that IAO either clarify these or change definitions not to use them</rdf
     <!-- http://purl.obolibrary.org/obo/IAO_0000300 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000300">
-        <obo:IAO_0000111 xml:lang="en">textual entity</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">Words, sentences, paragraphs, and the written (non-figure) parts of publications are all textual entities</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A textual entity is a part of a manifestation (FRBR sense), a generically dependent continuant whose concretizations are patterns of glyphs intended to be interpreted as words, formulas, etc.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">AR, (IAO call 2009-09-01): a document as a whole is not typically a textual entity, because it has pictures in it - rather there are parts of it that are textual entities. Examples: The title, paragraph 2 sentence 7, etc.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">MC, 2009-09-14 (following IAO call 2009-09-01): textual entities live at the FRBR (http://en.wikipedia.org/wiki/Functional_Requirements_for_Bibliographic_Records) manifestation level. Everything is significant: line break, pdf and html versions of same document are different textual entities.</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Lawrence Hunter</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">text</obo:IAO_0000118>
     </owl:Class>
     
@@ -713,10 +421,8 @@ Request that IAO either clarify these or change definitions not to use them</rdf
     <!-- http://purl.obolibrary.org/obo/IAO_0000310 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000310">
-        <obo:IAO_0000111 xml:lang="en">document</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">A journal article, patent application, laboratory notebook, or a book</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A collection of information content entities intended to be understood together as a whole</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Lawrence Hunter</obo:IAO_0000117>
     </owl:Class>
     
 
@@ -724,12 +430,10 @@ Request that IAO either clarify these or change definitions not to use them</rdf
     <!-- http://purl.obolibrary.org/obo/IAO_0000612 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000612">
-        <obo:IAO_0000111 xml:lang="en">availability textual entity</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">From Qi et al. BMC Bioinformatics. 2014; 15: 11. (http://www.ncbi.nlm.nih.gov/pmc/articles/PMC3897912/):
 
 Project home page:http://krux.googlecode.com</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A textual entity expressing the location of a resource, e.g. software, or the manner in which a resource can be obtained.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Bill Baumgartner</obo:IAO_0000117>
     </owl:Class>
     
 
@@ -737,12 +441,10 @@ Project home page:http://krux.googlecode.com</obo:IAO_0000112>
     <!-- http://purl.obolibrary.org/obo/IAO_0000619 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000619">
-        <obo:IAO_0000111 xml:lang="en">consent textual entity</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">From Shiba et al. Acta Neuropathol Commun. 2013; 1: 45. (http://www.ncbi.nlm.nih.gov/pmc/articles/PMC3893467/):
 
 Written informed consent was obtained from the patient’s parents for publication of this Case report and any accompanying images. A copy of the written consent is available for review by the Editor-in chief of this journal.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A textual entity that documents the consenting process used to enroll patients in a study.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Bill Baumgartner</obo:IAO_0000117>
     </owl:Class>
     
 
@@ -750,7 +452,6 @@ Written informed consent was obtained from the patient’s parents for publicati
     <!-- http://purl.obolibrary.org/obo/IAO_0020000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0020000">
-        <obo:IAO_0000111 xml:lang="en">identifier</obo:IAO_0000111>
         <obo:IAO_0000115 xml:lang="en">An identifier is an information content entity that is the outcome of a dubbing process and is used to refer to one instance of entity shared by a group of people to refer to that individual entity.</obo:IAO_0000115>
     </owl:Class>
     
@@ -760,16 +461,6 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0000001">
         <obo:IAO_0000115>A disease is a disposition to undergo pathological processes that exists in an organism because of one or more disorders in that organism.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>DOID:4</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000408</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:N18</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:799.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D004194</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C2991</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>OGMS:0000031</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Orphanet:377788</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:64572001</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0012634</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>condition</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disease or disorder</oboInOwl:hasExactSynonym>
@@ -780,7 +471,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>disorders</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>medical condition</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>other disease</oboInOwl:hasExactSynonym>
-        <oboInOwl:id>MONDO:0000001</oboInOwl:id>
     </owl:Class>
     
 
@@ -790,9 +480,6 @@ Written informed consent was obtained from the patient’s parents for publicati
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0002051">
         <obo:IAO_0000115>A disease involving the integumental system.</obo:IAO_0000115>
         <oboInOwl:hasAlternativeId>MONDO:0045027</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasDbXref>DOID:16</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:128598002</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C1290011</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>disease of integumental system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disease or disorder of integumental system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disorder of integumental system</oboInOwl:hasExactSynonym>
@@ -801,7 +488,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>integumentary disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of integument</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of integumental system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0002051</oboInOwl:id>
     </owl:Class>
     
 
@@ -810,12 +496,6 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0002081">
         <obo:IAO_0000115>A disease involving the musculoskeletal system.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>DOID:17</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:729.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D009140</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C107377</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:928000</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0026857</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>disease of musculoskeletal system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disease or disorder of musculoskeletal system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disorder of musculoskeletal system</oboInOwl:hasExactSynonym>
@@ -825,7 +505,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>musculoskeletal system disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of musculoskeletal system</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>musculoskeletal disorder</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0002081</oboInOwl:id>
     </owl:Class>
     
 
@@ -834,12 +513,6 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0003900">
         <obo:IAO_0000115>A disease involving the connective tissue.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>COHD:253549</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>DOID:65</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D003240</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C26729</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:105969002</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0009782</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>connective tissue disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>connective tissue disease or disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>connective tissue diseases</oboInOwl:hasExactSynonym>
@@ -852,7 +525,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>primary disorder of connective tissue</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>tissue disease, connective</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of connective tissue</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0003900</oboInOwl:id>
     </owl:Class>
     
 
@@ -861,15 +533,6 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0004335">
         <obo:IAO_0000115>A disease or disorder that involves the digestive system.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>COHD:4201745</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>DOID:77</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000405</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:K92.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:520-579.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:V47.3</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D005767</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C2990</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:53619000</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>alimentary system disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>digestive disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>digestive system disease</oboInOwl:hasExactSynonym>
@@ -888,7 +551,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>git disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>stomach or intestinal disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of digestive system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0004335</oboInOwl:id>
     </owl:Class>
     
 
@@ -897,23 +559,6 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0004992">
         <obo:IAO_0000115>A tumor composed of atypical neoplastic, often pleomorphic cells that invade other tissues. Malignant neoplasms often metastasize to distant anatomic sites and may recur after excision. The most common malignant neoplasms are carcinomas (adenocarcinomas or squamous cell carcinomas), Hodgkin and non-Hodgkin lymphomas, leukemias, melanomas, and sarcomas.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>COHD:443392</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>DOID:0050686</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>DOID:0050687</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>DOID:162</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000311</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>GARD:0011960</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:C80</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:C80.1</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:195.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:199</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:199.1</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICDO:8000/3</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C9305</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NIFSTD:birnlex_406</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ONCOTREE:MT</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:363346000</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0006826</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>CA</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>cancer</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>cell type cancer</oboInOwl:hasExactSynonym>
@@ -928,7 +573,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>organ system cancer</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>primary cancer</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>MT</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0004992</oboInOwl:id>
     </owl:Class>
     
 
@@ -937,26 +581,6 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0004995">
         <obo:IAO_0000115>A disease involving the cardiovascular system.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>DOID:1287</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000319</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:I00.I99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:390-459.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:420-429.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:423</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:423.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:424</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:429</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:429.2</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:429.7</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:429.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:429.81</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:429.89</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:459.89</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:459.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D002318</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C2931</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:49601007</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0007222</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>cardiovascular disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>cardiovascular disease (CVD)</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>cardiovascular disorder</oboInOwl:hasExactSynonym>
@@ -968,7 +592,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>disorder of cardiovascular system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>circulatory system disease</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of cardiovascular system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0004995</oboInOwl:id>
     </owl:Class>
     
 
@@ -977,19 +600,6 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0005071">
         <obo:IAO_0000115>A non-neoplastic or neoplastic disorder that affects the brain, spinal cord, or peripheral nerves.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>DOID:863</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000618</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:G00-G99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:G00.G99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:G98</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:G98.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:349.89</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:349.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D009422</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C26835</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:118940003</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0027765</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Wikipedia:Nervous_system_disease</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>disease of nervous system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disease or disorder of nervous system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disorder of nervous system</oboInOwl:hasExactSynonym>
@@ -1001,7 +611,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>neurological disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>neurological disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of nervous system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005071</oboInOwl:id>
     </owl:Class>
     
 
@@ -1010,19 +619,10 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0005084">
         <obo:IAO_0000115>A disease that has its basis in the disruption of mental process.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>EFO:0000677</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:F00.F99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:290-299.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:298.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:V11.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NIFSTD:birnlex_12669</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:74732009</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:CN240636</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>disorder of mental process</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>mental or behavioural disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>mental process disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of mental process</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005084</oboInOwl:id>
     </owl:Class>
     
 
@@ -1031,33 +631,6 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0005087">
         <obo:IAO_0000115>A non-neoplastic or neoplastic disorder that affects the respiratory system. Representative examples include pneumonia, chronic obstructive pulmonary disease, pulmonary failure, lung adenoma, lung carcinoma, and tracheal carcinoma.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>DOID:1579</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000684</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:J96-J99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:J98</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:460-519.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:500-508.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:503</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:508</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:508.1</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:508.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:508.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:510-519.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:516</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:516.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:516.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:517</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:517.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:519</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:519.1</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:519.3</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:519.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:519.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:V12.60</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:V47.2</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D012140</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C26871</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:50043002</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>disease of respiratory system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disease or disorder of respiratory system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disorder of respiratory system</oboInOwl:hasExactSynonym>
@@ -1067,7 +640,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>respiratory system disease or disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>respiratory system disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of respiratory system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005087</oboInOwl:id>
     </owl:Class>
     
 
@@ -1076,15 +648,6 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0005151">
         <obo:IAO_0000115>A disease involving the endocrine system.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>DOID:28</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0001379</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:E34.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:259.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:259.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D004700</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C3009</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:362969004</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0014130</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>disease of endocrine system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disease or disorder of endocrine system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disorder of endocrine system</oboInOwl:hasExactSynonym>
@@ -1096,7 +659,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>endocrinopathy</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>thyroid or other glandular disorders</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of endocrine system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005151</oboInOwl:id>
     </owl:Class>
     
 
@@ -1105,16 +667,6 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0005550">
         <obo:IAO_0000115>A disorder resulting from the presence and activity of a microbial, viral, or parasitic agent. It can be transmitted by direct or indirect contact.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>DOID:0050117</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0005741</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:A00.B99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:079.0</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:136.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:136.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>IDO:0000436</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D003141</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C26726</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:40733004</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>ID</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>clinical infection</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>communicable disease</oboInOwl:hasExactSynonym>
@@ -1125,7 +677,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>infectious disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>transmissible disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disease by infectious agent</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005550</oboInOwl:id>
         <rdfs:comment>Replaces &apos;infection&apos; in disease hierarchy. OBI imported term infection is moved to pathologic process. This class is a container class for infectious diseases, not the process of infection itself.</rdfs:comment>
     </owl:Class>
     
@@ -1135,20 +686,6 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0005570">
         <obo:IAO_0000115>A disease involving the hematopoietic system.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>DOID:74</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0005803</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>GTR:AN1320635</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:D75.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:280-289.99</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:289.8</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD9:289.9</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D006402</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C26323</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>Orphanet:97992</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:414022008</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0018939</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:CN206939</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:CN882913</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>blood disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>blood disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>blood dyscrasia</oboInOwl:hasExactSynonym>
@@ -1168,9 +705,7 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasRelatedSynonym>blood dyscrasia NOS</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of hematopoietic system</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>hematological disorders and malignancies</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005570</oboInOwl:id>
         <rdfs:comment>placeholder for lymphoid disease</rdfs:comment>
-        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/monarch-initiative/mondo/issues/254</rdfs:seeAlso>
     </owl:Class>
     
 
@@ -1179,16 +714,10 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0021178">
         <obo:IAO_0000115>Damage inflicted on the body as the direct or indirect result of an external force, with or without disruption of structural continuity.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>COHD:440921</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000546</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ICD10:S00.T98</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D014947</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C3671</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>injury</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>trauma</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>traumatic injury</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>wound</oboInOwl:hasExactSynonym>
-        <oboInOwl:id>MONDO:0021178</oboInOwl:id>
     </owl:Class>
     
 
@@ -1197,7 +726,6 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0024458">
         <obo:IAO_0000115>A disease that involves the visual system.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>SCTID:128127008</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>disease of visual system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disease or disorder of visual system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disorder of visual system</oboInOwl:hasExactSynonym>
@@ -1205,7 +733,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>visual system disease or disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>visual system disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of visual system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0024458</oboInOwl:id>
     </owl:Class>
     
 
@@ -1214,12 +741,6 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0024623">
         <obo:IAO_0000115>Pathological processes of the ear, the nose, and the throat, also known as the ENT diseases.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>ICD9:478.19</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D010038</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C118420</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:232208008</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0029896</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0395797</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>ear, nose and throat disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>ear, nose or throat disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>ear/nose/throat disease</oboInOwl:hasExactSynonym>
@@ -1243,7 +764,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasRelatedSynonym>otolaryngological diseases</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>otorhinolaryngological disease</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>otorhinolaryngological diseases</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0024623</oboInOwl:id>
         <rdfs:comment>Editor note: consider uberon class</rdfs:comment>
     </owl:Class>
     
@@ -1253,14 +773,9 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0029000">
         <obo:IAO_0000115>A condition or physical state produced by the ingestion, injection, inhalation of or exposure to a deleterious agent.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>EFO:0008546</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D011041</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SCTID:75478009</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0302332</oboInOwl:hasDbXref>
         <oboInOwl:hasRelatedSynonym>Poisonings</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>intoxication</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>poisoning syndrome</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0029000</oboInOwl:id>
     </owl:Class>
     
 
@@ -1268,15 +783,9 @@ Written informed consent was obtained from the patient’s parents for publicati
     <!-- http://purl.obolibrary.org/obo/OBI_0000011 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000011">
-        <obo:IAO_0000111>planned process</obo:IAO_0000111>
         <obo:IAO_0000112>Injecting mice with a vaccine in order to test its efficacy</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A process that realizes a plan which is the concretization of a plan specification.</obo:IAO_0000115>
-        <obo:IAO_0000116>&apos;Plan&apos; includes a future direction sense. That can be problematic if plans are changed during their execution. There are however implicit contingencies for protocols that an agent has in his mind that can be considered part of the plan, even if the agent didn&apos;t have them in mind before. Therefore, a planned process can diverge from what the agent would have said the plan was before executing it, by adjusting to problems encountered during execution (e.g. choosing another reagent with equivalent properties, if the originally planned one has run out.)</obo:IAO_0000116>
-        <obo:IAO_0000116>We are only considering successfully completed planned processes. A plan may be modified, and details added during execution. For a given planned process, the associated realized plan specification is the one encompassing all changes made during execution. This means that all processes in which an agent acts towards achieving some 
-objectives is a planned process.</obo:IAO_0000116>
-        <obo:IAO_0000117>Bjoern Peters</obo:IAO_0000117>
         <obo:IAO_0000119>branch derived</obo:IAO_0000119>
-        <obo:IAO_0000232>6/11/9: Edited at workshop. Used to include: is initiated by an agent</obo:IAO_0000232>
     </owl:Class>
     
 
@@ -1284,16 +793,11 @@ objectives is a planned process.</obo:IAO_0000116>
     <!-- http://purl.obolibrary.org/obo/OBI_0000070 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000070">
-        <obo:IAO_0000111 xml:lang="en">assay</obo:IAO_0000111>
         <obo:IAO_0000112>Assay the wavelength of light emitted by excited Neon atoms. Count of geese flying over a house.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A planned process with the objective to produce information about the material entity that is the evaluant, by physically examining it or its proxies.</obo:IAO_0000115>
-        <obo:IAO_0000116>12/3/12: BP: the reference to the &apos;physical examination&apos; is included to point out that a prediction is not an assay, as that does not require physical examiniation.</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">PlanAndPlannedProcess Branch</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">measuring</obo:IAO_0000118>
         <obo:IAO_0000118 xml:lang="en">scientific observation</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">OBI branch derived</obo:IAO_0000119>
-        <obo:OBI_0001847>study assay</obo:OBI_0001847>
-        <obo:OBI_9991118>any method</obo:OBI_9991118>
     </owl:Class>
     
 
@@ -1301,13 +805,8 @@ objectives is a planned process.</obo:IAO_0000116>
     <!-- http://purl.obolibrary.org/obo/OBI_0000094 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000094">
-        <obo:IAO_0000111>material processing</obo:IAO_0000111>
         <obo:IAO_0000112>A cell lysis, production of a cloning vector, creating a buffer.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A planned process which results in physical changes in a specified input material</obo:IAO_0000115>
-        <obo:IAO_0000117>PERSON: Frank Gibson</obo:IAO_0000117>
-        <obo:IAO_0000117>PERSON: Jennifer Fostel</obo:IAO_0000117>
-        <obo:IAO_0000117>PERSON: Melanie Courtot</obo:IAO_0000117>
-        <obo:IAO_0000117>PERSON: Philippe Rocca Serra</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">material transformation</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">OBI branch derived</obo:IAO_0000119>
     </owl:Class>
@@ -1317,10 +816,8 @@ objectives is a planned process.</obo:IAO_0000116>
     <!-- http://purl.obolibrary.org/obo/OBI_0000435 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000435">
-        <obo:IAO_0000111>genotyping assay</obo:IAO_0000111>
         <obo:IAO_0000112>High-throughput genotyping of oncogenic human papilloma viruses with MALDI-TOF mass spectrometry. Clin Chem. 2008 Jan;54(1):86-92. Epub 2007 Nov 2.PMID: 17981923</obo:IAO_0000112>
         <obo:IAO_0000115>An assay which generates data about a genotype from a specimen of genomic DNA. A variety of techniques and instruments can be used to produce information about sequence variation at particular genomic positions.</obo:IAO_0000115>
-        <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000118>SNP analysis</obo:IAO_0000118>
         <obo:IAO_0000118>genotype profiling</obo:IAO_0000118>
         <obo:IAO_0000119>OBI Biomaterial</obo:IAO_0000119>
@@ -1331,10 +828,8 @@ objectives is a planned process.</obo:IAO_0000116>
     <!-- http://purl.obolibrary.org/obo/OBI_0000537 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000537">
-        <obo:IAO_0000111>copy number variation profiling assay</obo:IAO_0000111>
         <obo:IAO_0000112>Profiling of copy number variations (CNVs) in healthy individuals from three ethnic groups using a human genome 32 K BAC-clone-based array. PMID:18058796</obo:IAO_0000112>
         <obo:IAO_0000115>An assay that determines lost or amplified genomic regions of DNA by comparing genomic DNA originating from tissues from the same or different individuals using specific techniques such as CGH, array CGH, SNP genotyping</obo:IAO_0000115>
-        <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000118>CNV analysis</obo:IAO_0000118>
     </owl:Class>
     
@@ -1343,9 +838,7 @@ objectives is a planned process.</obo:IAO_0000116>
     <!-- http://purl.obolibrary.org/obo/OBI_0001271 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0001271">
-        <obo:IAO_0000111>RNA-seq assay</obo:IAO_0000111>
         <obo:IAO_0000115>An transcription profiling assay that determines an RNA sequence by analyzing the transcibed regions of the genome and or to quantitate transcript abundance.</obo:IAO_0000115>
-        <obo:IAO_0000117>James Malone</obo:IAO_0000117>
         <obo:IAO_0000118>transcription profiling by high throughput sequencing</obo:IAO_0000118>
         <obo:IAO_0000119>EFO:0002770</obo:IAO_0000119>
     </owl:Class>
@@ -1355,10 +848,7 @@ objectives is a planned process.</obo:IAO_0000116>
     <!-- http://purl.obolibrary.org/obo/OBI_0001624 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0001624">
-        <obo:IAO_0000111>organism identification assay</obo:IAO_0000111>
         <obo:IAO_0000115>An assay that identifies the organism species in a specimen.</obo:IAO_0000115>
-        <obo:IAO_0000117>Chris Stoeckert</obo:IAO_0000117>
-        <obo:IAO_0000117>Jie Zheng</obo:IAO_0000117>
         <obo:IAO_0000119>NIAID GSCID-BRC metadata working group</obo:IAO_0000119>
     </owl:Class>
     
@@ -1367,10 +857,7 @@ objectives is a planned process.</obo:IAO_0000116>
     <!-- http://purl.obolibrary.org/obo/OBI_0002020 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0002020">
-        <obo:IAO_0000111>epigenetic modification assay</obo:IAO_0000111>
         <obo:IAO_0000115>An assay that identifies epigenetic modifications including histone modifications, open chromatin, and DNA methylation.</obo:IAO_0000115>
-        <obo:IAO_0000117>Chris Stoeckert</obo:IAO_0000117>
-        <obo:IAO_0000117>Jie Zheng</obo:IAO_0000117>
         <obo:IAO_0000119>Penn group</obo:IAO_0000119>
     </owl:Class>
     
@@ -1379,11 +866,8 @@ objectives is a planned process.</obo:IAO_0000116>
     <!-- http://purl.obolibrary.org/obo/OBI_0002117 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0002117">
-        <obo:IAO_0000111>whole genome sequencing assay</obo:IAO_0000111>
         <obo:IAO_0000112>WGS permits comprehensive sequencing of introns and exons, whereas whole exome sequencing (WES) allows deeper sequencing of exonic regions at a lower cost. Due to the large number of genetic variants found in each genome, it is necessary to use filtering approaches to distinguish deleterious from benign variants. WES has been used successfully to identify novel genetic causes of primary immunodeficiency. Complex structural variations and non-Mendelian disorders remain challenges for WGS.</obo:IAO_0000112>
         <obo:IAO_0000115>A DNA sequencing assay that intends to provide information about the sequence of an entire genome of an organism.</obo:IAO_0000115>
-        <obo:IAO_0000116>Genotyping assays should ideally identify which part of the genome the information is about. We do not currently have a good way to do this. That information should be added later.</obo:IAO_0000116>
-        <obo:IAO_0000117>ImmPort</obo:IAO_0000117>
         <obo:IAO_0000118>WGS</obo:IAO_0000118>
         <obo:IAO_0000119>PMID:23095910</obo:IAO_0000119>
         <obo:IAO_0000119>PMID:25827230</obo:IAO_0000119>
@@ -1394,10 +878,8 @@ objectives is a planned process.</obo:IAO_0000116>
     <!-- http://purl.obolibrary.org/obo/OBI_0002118 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0002118">
-        <obo:IAO_0000111>exome sequencing assay</obo:IAO_0000111>
         <obo:IAO_0000112>DNA was extracted from the Ficoll pellet of blood taken from congenital asplenia patients. Unamplified, high-molecular weight, RNase-treated genomic DNA (4_6 _g) was used for whole exome sequencing (WES) with the use of Agilent 71 Mb (V4 + UTR) singlesample capture and an Illumina HiSeq 2000. Sequencing was carried out so as to obtain 30_ coverage from 2 _ 100-bp paired-end reads. We used the Annovar tool (25) to annotate the resulting highquality (HQ) variants. In the regions targeted by WES capture (81.5% of the consensus coding genome), the mean numbers of single-nucleotide variants (SNVs) and small insertions/deletions (indels) detected per sample were 84,192 and13,325, respectively. After filtering, a mean of 74,398 (95.3%) high-quality (HQ) SNVs and 9,033 (70.6%) HQ indels were called. A mean of 105 coding HQ SNVs and 32 indels was identified.</obo:IAO_0000112>
         <obo:IAO_0000115>A DNA sequencing assay that intends to provide information about the sequence of the protein coding components of a genome (exons).</obo:IAO_0000115>
-        <obo:IAO_0000117>ImmPort</obo:IAO_0000117>
         <obo:IAO_0000118>WES</obo:IAO_0000118>
         <obo:IAO_0000119>PMID:25827230</obo:IAO_0000119>
     </owl:Class>
@@ -1407,11 +889,8 @@ objectives is a planned process.</obo:IAO_0000116>
     <!-- http://purl.obolibrary.org/obo/OBI_0002415 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0002415">
-        <obo:IAO_0000111>exposure to environmental and workplace carcinogens history</obo:IAO_0000111>
         <obo:IAO_0000115>A information content entity that indicates the exposure of an individual to carcinogens in the workplace or environment.</obo:IAO_0000115>
-        <obo:IAO_0000117>Chris Stoeckert, Helena Ellis</obo:IAO_0000117>
         <obo:IAO_0000119>OBIB</obo:IAO_0000119>
-        <obo:IAO_0000234>NCI BBRB</obo:IAO_0000234>
     </owl:Class>
     
 
@@ -1419,14 +898,10 @@ objectives is a planned process.</obo:IAO_0000116>
     <!-- http://purl.obolibrary.org/obo/OBI_0002623 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0002623">
-        <obo:IAO_0000111>whole metagenome sequencing assay</obo:IAO_0000111>
         <obo:IAO_0000115>A DNA sequencing assay that intends to provide information on the DNA sequences of multiple genomes (a metagenome) from different organisms present in the same input sample.</obo:IAO_0000115>
-        <obo:IAO_0000116>Whole metagenome sequencing has been used to explore the composition and metabolic capability of communities of microbes found in the environment (e.g. in soil, water, etc.) and in humans and other species (e.g. in the gut, oral cavity, etc.).</obo:IAO_0000116>
-        <obo:IAO_0000117>Rebecca Jackson</obo:IAO_0000117>
         <obo:IAO_0000118>WMS</obo:IAO_0000118>
         <obo:IAO_0000119>Bjoern Peters</obo:IAO_0000119>
         <obo:IAO_0000119>Michelle Giglio</obo:IAO_0000119>
-        <obo:IAO_0000233>https://github.com/obi-ontology/obi/issues/1056</obo:IAO_0000233>
     </owl:Class>
     
 
@@ -1434,10 +909,8 @@ objectives is a planned process.</obo:IAO_0000116>
     <!-- http://purl.obolibrary.org/obo/OBI_0302893 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0302893">
-        <obo:IAO_0000111>storage</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">PMID: 18550121.Total Prostate Specific Antigen Stability Confirmed After Long-Term Storage of Serum at -80C. J Urol. 2008 Jun 10.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A maintenance process by which material entities that are not actively metabolizing are placed in well identified location and possibly under controlled environment in ad-hoc devices/structures in order to preserve and protect them from decay/alteration and maintain availability</obo:IAO_0000115>
-        <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000119>OBI-Branch</obo:IAO_0000119>
     </owl:Class>
     
@@ -1446,13 +919,9 @@ objectives is a planned process.</obo:IAO_0000116>
     <!-- http://purl.obolibrary.org/obo/OBI_0500000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0500000">
-        <obo:IAO_0000111 xml:lang="en">study design</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">a matched pairs study design describes criteria by which subjects are identified as pairs which then undergo the same protocols, and the data generated is analyzed by comparing the differences between the paired subjects, which constitute the results of the executed study design.</obo:IAO_0000112>
         <obo:IAO_0000115>A plan specification comprised of protocols (which may specify how and what kinds of data will be gathered) that are executed as part of an investigation and is realized during a study design execution.</obo:IAO_0000115>
-        <obo:IAO_0000116>Editor note: there is at least an implicit restriction on the kind of data transformations that can be done based on the measured data available.</obo:IAO_0000116>
-        <obo:IAO_0000117>PERSON: Chris Stoeckert</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">experimental design</obo:IAO_0000118>
-        <obo:IAO_0000232 xml:lang="en">rediscussed at length (MC/JF/BP). 12/9/08). The definition was clarified to differentiate it from protocol.</obo:IAO_0000232>
     </owl:Class>
     
 
@@ -1460,10 +929,8 @@ objectives is a planned process.</obo:IAO_0000116>
     <!-- http://purl.obolibrary.org/obo/OBI_0500027 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0500027">
-        <obo:IAO_0000111 xml:lang="en">inclusion criterion</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">PMID: 23979341-The major inclusion criterion was patients in whom severe cerebral embolism was diagnosed at age 75 or younger (more than 9 in the NIHSS score on day 7 after the onset of stroke) .</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">an inclusion criterion (rule) is_a *eligibility criterion*  which defines and states a condition which, if met, makes an entity suitable for a given task or participation in a given process. For instance, in a study protocol, inclusion criteria indicate the conditions that prospective subjects MUST meet to be eligible for participation in a study.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Person: Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">inclusion condition</obo:IAO_0000118>
         <obo:IAO_0000118 xml:lang="en">inclusion rule</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">Adapted from Clinical Research Glossary Version 4.0 CDICS glossary group</obo:IAO_0000119>
@@ -1475,9 +942,7 @@ objectives is a planned process.</obo:IAO_0000116>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OGMS_0000015">
         <obo:IAO_0000115 xml:lang="en">A series of statements representing health-relevant qualities of a patient and of a patient&apos;s family.</obo:IAO_0000115>
-        <obo:IAO_0000117>Albert Goldfain</obo:IAO_0000117>
         <obo:IAO_0000119>http://ontology.buffalo.edu/medo/Disease_and_Diagnosis.pdf</obo:IAO_0000119>
-        <obo:IAO_0000232>creation date: 2010-07-19T10:18:59Z</obo:IAO_0000232>
     </owl:Class>
     
 
@@ -1486,10 +951,7 @@ objectives is a planned process.</obo:IAO_0000116>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OGMS_0000020">
         <obo:IAO_0000115 xml:lang="en">A process experienced by the patient, which can only be experienced by the patient, that is hypothesized to be clinically relevant.</obo:IAO_0000115>
-        <obo:IAO_0000116>note: defined class</obo:IAO_0000116>
         <obo:IAO_0000119>http://ontology.buffalo.edu/medo/Disease_and_Diagnosis.pdf</obo:IAO_0000119>
-        <obo:IAO_0000232>creation date: 2010-11-18T11:02:10Z
-Updated: 2020-07-06</obo:IAO_0000232>
     </owl:Class>
     
 
@@ -1498,8 +960,6 @@ Updated: 2020-07-06</obo:IAO_0000232>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000011">
         <obo:IAO_0000115>A time quality inhering in a bearer by virtue of how long the bearer has existed.</obo:IAO_0000115>
-        <oboInOwl:hasOBONamespace>quality</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>PATO:0000011</oboInOwl:id>
     </owl:Class>
     
 
@@ -1508,8 +968,6 @@ Updated: 2020-07-06</obo:IAO_0000232>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000047">
         <obo:IAO_0000115>An organismal quality inhering in a bearer by virtue of the bearer&apos;s ability to undergo sexual reproduction in order to differentiate the individuals or types involved.</obo:IAO_0000115>
-        <oboInOwl:hasOBONamespace>quality</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>PATO:0000047</oboInOwl:id>
     </owl:Class>
     
 
@@ -1518,8 +976,6 @@ Updated: 2020-07-06</obo:IAO_0000232>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001995">
         <obo:IAO_0000115>A quality that inheres in an entire organism or part of an organism.</obo:IAO_0000115>
-        <oboInOwl:hasOBONamespace>quality</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>PATO:0001995</oboInOwl:id>
     </owl:Class>
     
 
@@ -1548,7 +1004,6 @@ Updated: 2020-07-06</obo:IAO_0000232>
     <!-- http://purl.obolibrary.org/obo/PDRO_0010022 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PDRO_0010022">
-        <obo:IAO_0000111 xml:lang="en">prescribed drug administration specification</obo:IAO_0000111>
         <obo:IAO_0000112>&apos;take Aspirin 81 mg oral tablet, 1 tablet once daily by mouth, start today&apos; or the synonymous abbreviated version &apos;Aspirin 81 mg tablet PO DIE&apos;</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A drug administration description that specifies a drug administration prescribed or reported by an healthcare provider.
 
@@ -1566,9 +1021,7 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000039">
         <obo:IAO_0000112 xml:lang="en"></obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">a statistic is a measurement datum to describe a dataset or a variable. It is generated by a calculation on set of observed data.</obo:IAO_0000115>
-        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">STATO, adapted from wikipedia (http://en.wikipedia.org/wiki/Statistic).</obo:IAO_0000119>
-        <obo:STATO_0000032 xml:lang="en">statistic</obo:STATO_0000032>
     </owl:Class>
     
 
@@ -1578,9 +1031,7 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000047">
         <obo:IAO_0000112 xml:lang="en">a count of 4 resulting from counting limbs in humans</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">a count is a data item denoted by an integer and represented the number of instances or occurences of an entity</obo:IAO_0000115>
-        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">STATO</obo:IAO_0000119>
-        <obo:STATO_0000032 xml:lang="en"></obo:STATO_0000032>
     </owl:Class>
     
 
@@ -1589,9 +1040,6 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000093">
         <obo:IAO_0000115 xml:lang="en">Information about a calendar date or timestamp indicating day, month, year and time of an event.</obo:IAO_0000115>
-        <obo:IAO_0000117>Alejandra Gonzalez-Beltran</obo:IAO_0000117>
-        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
-        <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">STATO</obo:IAO_0000119>
     </owl:Class>
     
@@ -1601,26 +1049,8 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000105">
         <obo:IAO_0000115>A spatiotemporal region encompassing some part of the life cycle of an organism.</obo:IAO_0000115>
-        <obo:IAO_0000116>this class represents a proper part of the life cycle of an organism. The class &apos;life cycle&apos; should not be placed here</obo:IAO_0000116>
-        <obo:UBPROP_0000012>the WBls class &apos;all stages&apos; belongs here as it is the superclass of other WBls stages</obo:UBPROP_0000012>
-        <obo:UBPROP_0000012>we map the ZFS unknown stage here as it is logically equivalent to saying *some* life cycle stage</obo:UBPROP_0000012>
-        <oboInOwl:hasDbXref>BILS:0000105</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000399</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>FBdv:00007012</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>FMA:24120</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>HsapDv:0000000</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MmusDv:0000000</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>OlatDv:0000010</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>PdumDv:0000090</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>WBls:0000002</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>XAO:1000000</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ZFS:0000000</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ZFS:0100000</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ncithesaurus:Developmental_Stage</oboInOwl:hasDbXref>
         <oboInOwl:hasNarrowSynonym>developmental stage</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasNarrowSynonym>stage</oboInOwl:hasNarrowSynonym>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>UBERON:0000105</oboInOwl:id>
     </owl:Class>
     
 
@@ -1629,38 +1059,9 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000178">
         <obo:IAO_0000115>A fluid that is composed of blood plasma and erythrocytes.</obo:IAO_0000115>
-        <obo:IAO_0000232>This class excludes blood analogues, such as the insect analog of blood. See UBERON:0000179 haemolymphatic fluid.</obo:IAO_0000232>
-        <obo:UBPROP_0000001>A complex mixture of cells suspended in a liquid matrix that delivers nutrients to cells and removes wastes. (Source: BioGlossary, www.Biology-Text.com)[TAO]</obo:UBPROP_0000001>
-        <obo:UBPROP_0000001>Highly specialized circulating tissue consisting of several types of cells suspended in a fluid medium known as plasma.[AAO]</obo:UBPROP_0000001>
-        <obo:UBPROP_0000002>relationship loss: subclass specialized connective tissue (AAO:0000571)[AAO]</obo:UBPROP_0000002>
-        <obo:UBPROP_0000003>Recent findings strongly suggest that the molecular pathways involved in the development and function of blood cells are highly conserved among vertebrates and various invertebrates phyla. (...) There is now good reason to believe that, in vertebrates and invertebrates alike, blood cell lineages diverge from a common type of progenitor cell, the hemocytoblast.[well established][VHOG]</obo:UBPROP_0000003>
-        <oboInOwl:hasDbXref>AAO:0000046</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>BTO:0000089</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>CALOHA:TS-0079</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0000296</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EHDAA2:0000176</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EHDAA:418</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EMAPA:16332</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ENVO:02000027</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EV:0100047</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>FMA:9670</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>GAID:965</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MA:0000059</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D001769</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MIAA:0000315</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C12434</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>OpenCyc:Mx4rvVjI8JwpEbGdrcN5Y29ycA</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>TAO:0000007</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0005767</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>VHOG:0000224</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>XAO:0000124</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ZFA:0000007</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>galen:Blood</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>portion of blood</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>vertebrate blood</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
         <oboInOwl:hasRelatedSynonym>whole blood</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>UBERON:0000178</oboInOwl:id>
     </owl:Class>
     
 
@@ -1669,32 +1070,11 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000463">
         <obo:IAO_0000115>Material anatomical entity in a gaseous, liquid, semisolid or solid state; produced by anatomical structures or derived from inhaled and ingested substances that have been modified by anatomical structures as they pass through the body.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>AAO:0010839</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>AEO:0000004</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>BILA:0000004</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>CALOHA:TS-2101</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>CARO:0000004</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EHDAA2:0003004</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EMAPA:35178</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>FBbt:00007019</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>FMA:9669</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>HAO:0000004</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MA:0002450</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C13236</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>SPD:0000008</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>TAO:0001487</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>TGMA:0001824</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>VHOG:0001726</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>XAO:0004001</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ZFA:0001487</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>galen:BodySubstance</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>body fluid or substance</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>body substance</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>organism substance</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>portion of body substance</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>portion of organism substance</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>UBERON:0000463</oboInOwl:id>
     </owl:Class>
     
 
@@ -1703,24 +1083,6 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001088">
         <obo:IAO_0000115>Excretion that is the output of a kidney</obo:IAO_0000115>
-        <obo:UBPROP_0000008>kidney excreta from some taxa (e.g. in aves) may not be liquid</obo:UBPROP_0000008>
-        <oboInOwl:hasDbXref>BTO:0001419</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>CALOHA:TS-1092</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EFO:0001939</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EMAPA:36554</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ENVO:00002047</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>FMA:12274</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>GAID:1189</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MA:0002545</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MAT:0000058</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D014556</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MIAA:0000058</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C13283</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>OpenCyc:Mx4rvVjGppwpEbGdrcN5Y29ycA</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0042036</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>galen:Urine</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>UBERON:0001088</oboInOwl:id>
     </owl:Class>
     
 
@@ -1729,27 +1091,10 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001836">
         <obo:IAO_0000115>A fluid produced in the oral cavity by salivary glands, typically used in predigestion, but also in other functions.</obo:IAO_0000115>
-        <obo:UBPROP_0000007>salivary</obo:UBPROP_0000007>
-        <obo:UBPROP_0000008>We classify a wide variety of not necessarily homologous fluids here. In humans, the saliva is a turbid and slightly viscous fluid, generally of an alkaline reaction, and is secreted by the parotid, submaxillary, and sublingual glands. In the mouth the saliva is mixed with the secretion from the buccal glands. In man and many animals, saliva is an important digestive fluid on account of the presence of the peculiar enzyme, ptyalin</obo:UBPROP_0000008>
-        <oboInOwl:hasDbXref>BTO:0001202</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>CALOHA:TS-0891</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>EMAPA:36536</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ENVO:02000036</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>FMA:59862</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>GAID:1167</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MA:0002507</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MAT:0000444</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D012463</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C13275</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>OpenCyc:Mx4rvVjJ95wpEbGdrcN5Y29ycA</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0036087</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>galen:Saliva</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>salivary gland secretion</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
         <oboInOwl:hasRelatedSynonym>sailva normalis</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>saliva atomaris</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>saliva molecularis</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>UBERON:0001836</oboInOwl:id>
     </owl:Class>
     
 
@@ -1758,22 +1103,7 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001988">
         <obo:IAO_0000115>Portion of semisolid bodily waste discharged through the anus[MW,modified]</obo:IAO_0000115>
-        <obo:UBPROP_0000001>Excretion in semisolid state processed by the intestine.[FMA]</obo:UBPROP_0000001>
-        <obo:UBPROP_0000007>fecal</obo:UBPROP_0000007>
         <oboInOwl:hasBroadSynonym>excreta</oboInOwl:hasBroadSynonym>
-        <oboInOwl:hasDbXref>BTO:0000440</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>CALOHA:TS-2345</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>ENVO:00002003</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>FMA:64183</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>GAID:1199</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MA:0002509</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MAT:0000053</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MESH:D005243</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>MIAA:0000053</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>NCIT:C13234</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>OpenCyc:Mx4rvVjJMZwpEbGdrcN5Y29ycA</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>UMLS:C0015733</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>galen:Feces</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>faeces</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>fecal material</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>fecal matter</oboInOwl:hasExactSynonym>
@@ -1801,12 +1131,10 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
         <oboInOwl:hasNarrowSynonym>portion of scat</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasNarrowSynonym>scat</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasNarrowSynonym>spraint</oboInOwl:hasNarrowSynonym>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
         <oboInOwl:hasRelatedSynonym>droppings</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>excrement</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>ordure</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>spoor</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>UBERON:0001988</oboInOwl:id>
     </owl:Class>
 </rdf:RDF>
 

--- a/src/ontology/templates/properties.tsv
+++ b/src/ontology/templates/properties.tsv
@@ -15,4 +15,5 @@ oboInOwl:hasNarrowSynonym	has_narrow_synonym	owl:AnnotationProperty
 oboInOwl:hasRelatedSynonym	has_related_synonym	owl:AnnotationProperty
 rdfs:comment	comment	owl:AnnotationProperty
 rdfs:label	label	owl:AnnotationProperty
+rdfs:seeAlso	see also	owl:AnnotationProperty
 RO:0000052	inheres in	owl:ObjectProperty

--- a/src/ontology/templates/properties.tsv
+++ b/src/ontology/templates/properties.tsv
@@ -3,32 +3,16 @@ ID	LABEL	TYPE
 BFO:0000050	part of	owl:ObjectProperty
 GECKO:9000000	IHCC category	owl:AnnotationProperty
 GECKO:9000001	IHCC browser label	owl:AnnotationProperty
-IAO:0000111	editor preferred term	owl:AnnotationProperty
 IAO:0000112	example of usage	owl:AnnotationProperty
 IAO:0000115	definition	owl:AnnotationProperty
-IAO:0000116	editor note	owl:AnnotationProperty
-IAO:0000117	term editor	owl:AnnotationProperty
 IAO:0000118	alternative term	owl:AnnotationProperty
 IAO:0000119	definition source	owl:AnnotationProperty
 IAO:0000136	is about	owl:ObjectProperty
-IAO:0000232	curator note	owl:AnnotationProperty
-IAO:0000233	term tracker item	owl:AnnotationProperty
-IAO:0000234	ontology term requester	owl:AnnotationProperty
-obo:UBPROP_0000001	external_definition	owl:AnnotationProperty
-obo:UBPROP_0000002	axiom_lost_from_external_ontology	owl:AnnotationProperty
-obo:UBPROP_0000003	homology_notes	owl:AnnotationProperty
-obo:UBPROP_0000007	has_relational_adjective	owl:AnnotationProperty
-obo:UBPROP_0000008	taxon_notes	owl:AnnotationProperty
-obo:UBPROP_0000012	external_ontology_notes	owl:AnnotationProperty
 oboInOwl:hasAlternativeId	has_alternative_id	owl:AnnotationProperty
 oboInOwl:hasBroadSynonym	has_broad_synonym	owl:AnnotationProperty
 oboInOwl:hasExactSynonym	has_exact_synonym	owl:AnnotationProperty
 oboInOwl:hasNarrowSynonym	has_narrow_synonym	owl:AnnotationProperty
-oboInOwl:hasOBONamespace	has_obo_namespace	owl:AnnotationProperty
 oboInOwl:hasRelatedSynonym	has_related_synonym	owl:AnnotationProperty
-oboInOwl:id	id	owl:AnnotationProperty
-oboInOwl:inSubset	in_subset	owl:AnnotationProperty
 rdfs:comment	comment	owl:AnnotationProperty
 rdfs:label	label	owl:AnnotationProperty
-rdfs:seeAlso	see also	owl:AnnotationProperty
 RO:0000052	inheres in	owl:ObjectProperty

--- a/src/scripts/prefixes.sql
+++ b/src/scripts/prefixes.sql
@@ -31,6 +31,7 @@ INSERT OR IGNORE INTO prefix VALUES
 ("PCO",       "http://purl.obolibrary.org/obo/PCO_"),
 ("PDRO",      "http://purl.obolibrary.org/obo/PDRO_"),
 ("PR",        "http://purl.obolibrary.org/obo/PR_"),
+("rdf",       "http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
 ("rdfs",      "http://www.w3.org/2000/01/rdf-schema#"),
 ("RO",        "http://purl.obolibrary.org/obo/RO_"),
 ("STATO",     "http://purl.obolibrary.org/obo/STATO_"),

--- a/views/ihcc-gecko.owl
+++ b/views/ihcc-gecko.owl
@@ -9,7 +9,7 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/gecko/ihcc-gecko.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/gecko/releases/2020-10-26/views/ihcc-gecko.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/gecko/releases/2020-10-27/views/ihcc-gecko.owl"/>
     </owl:Ontology>
     
 
@@ -101,6 +101,14 @@
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#comment">
         <rdfs:label>comment</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.w3.org/2000/01/rdf-schema#seeAlso -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#seeAlso">
+        <rdfs:label>see also</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -1248,6 +1256,7 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasRelatedSynonym>hematological disorders and malignancies</oboInOwl:hasRelatedSynonym>
         <rdfs:comment>placeholder for lymphoid disease</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">blood-related disorders</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/monarch-initiative/mondo/issues/254</rdfs:seeAlso>
     </owl:Class>
     
 

--- a/views/ihcc-gecko.owl
+++ b/views/ihcc-gecko.owl
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="http://purl.obolibrary.org/obo/gecko/ihcc-gecko.owl#"
      xml:base="http://purl.obolibrary.org/obo/gecko/ihcc-gecko.owl"
-     xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -10,7 +9,7 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/gecko/ihcc-gecko.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/gecko/releases/2020-09-18/views/ihcc-gecko.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/gecko/releases/2020-10-26/views/ihcc-gecko.owl"/>
     </owl:Ontology>
     
 
@@ -23,14 +22,6 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000111 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000111">
-        <rdfs:label>editor preferred term</rdfs:label>
-    </owl:AnnotationProperty>
     
 
 
@@ -50,22 +41,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000116 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116">
-        <rdfs:label>editor note</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000117 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000117">
-        <rdfs:label>term editor</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/IAO_0000118 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000118">
@@ -79,84 +54,6 @@
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000119">
         <rdfs:label>definition source</rdfs:label>
     </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000232 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000232">
-        <rdfs:label>curator note</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000233 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000233">
-        <rdfs:label>term tracker item</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000234 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000234">
-        <rdfs:label>ontology term requester</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000001 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000001">
-        <rdfs:label>external_definition</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000002 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000002">
-        <rdfs:label>axiom_lost_from_external_ontology</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000003 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000003">
-        <rdfs:label>homology_notes</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000007 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000007">
-        <rdfs:label>has_relational_adjective</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000008 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000008">
-        <rdfs:label>taxon_notes</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBPROP_0000012 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000012">
-        <rdfs:label>external_ontology_notes</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.org/dc/elements/1.1/source -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/source"/>
     
 
 
@@ -192,14 +89,6 @@
     
 
 
-    <!-- http://www.geneontology.org/formats/oboInOwl#hasOBONamespace -->
-
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasOBONamespace">
-        <rdfs:label>has_obo_namespace</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
     <!-- http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym">
@@ -208,34 +97,10 @@
     
 
 
-    <!-- http://www.geneontology.org/formats/oboInOwl#id -->
-
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#id">
-        <rdfs:label>id</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://www.geneontology.org/formats/oboInOwl#inSubset -->
-
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#inSubset">
-        <rdfs:label>in_subset</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
     <!-- http://www.w3.org/2000/01/rdf-schema#comment -->
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#comment">
         <rdfs:label>comment</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://www.w3.org/2000/01/rdf-schema#seeAlso -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#seeAlso">
-        <rdfs:label>see also</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -319,9 +184,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000147">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000116"/>
         <obo:IAO_0000115>An information content entity indicating the cause of death for a participant in the study.</obo:IAO_0000115>
-        <obo:IAO_0000117>Person:  Jie Zheng, Chris Stoeckert, David Roos, Grant Dorsey</obo:IAO_0000117>
         <obo:IAO_0000119>Penn Group</obo:IAO_0000119>
-        <dc:source>PRISM</dc:source>
         <oboInOwl:hasExactSynonym>cause of participant death</oboInOwl:hasExactSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cause of death</rdfs:label>
     </owl:Class>
@@ -333,10 +196,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000308">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/EUPATH_0000451"/>
         <obo:IAO_0000115 xml:lang="en">an information content entity that is about a part of a health care encounter that occurs in a hospital facility</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Person: John Judkins</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">EuPathDB</obo:IAO_0000119>
         <oboInOwl:hasExactSynonym>hospitalization information</oboInOwl:hasExactSynonym>
-        <oboInOwl:inSubset>ICEMR protein array</oboInOwl:inSubset>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hospitalizations</rdfs:label>
     </owl:Class>
     
@@ -358,7 +219,6 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000374">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001995"/>
         <obo:IAO_0000115 xml:lang="en">a categorical value specification that is about a human being and specifies whether that human being is joined to another human being in marriage</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Person: John Judkins</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">EuPathDB, BFO&apos;s &apos;relational quality&apos; examples</obo:IAO_0000119>
         <oboInOwl:hasExactSynonym>marital status</oboInOwl:hasExactSynonym>
         <rdfs:label>marital status</rdfs:label>
@@ -382,9 +242,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0010032">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000056"/>
         <obo:IAO_0000115>environmental system associated with the dwelling used by humans.</obo:IAO_0000115>
-        <obo:IAO_0000117>Person:  Cristian Cocos, Jie Zheng, Chris Stoeckert</obo:IAO_0000117>
         <obo:IAO_0000119>Penn Group</obo:IAO_0000119>
-        <dc:source>GEMS</dc:source>
         <oboInOwl:hasExactSynonym>environment associated with human dwelling</oboInOwl:hasExactSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">physical environment</rdfs:label>
     </owl:Class>
@@ -1078,16 +936,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000005">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000001"/>
-        <obo:IAO_0000111 xml:lang="en">objective specification</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">In the protocol of a ChIP assay the objective specification says to identify protein and DNA interaction.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A directive information entity that describes an intended process endpoint. When part of a plan specification the concretization is realized in a planned process in which the bearer tries to effect the world so that the process endpoint is achieved.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">2009-03-16: original definition when imported from OBI read: &quot;objective is an non realizable information entity which can serve as that  proper part of a plan towards which the realization of the plan is directed.&quot;</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">2014-03-31: In the example of usage (&quot;In the protocol of a ChIP assay the objective specification says to identify protein and DNA interaction&quot;) there is a protocol which is the ChIP assay protocol. In addition to being concretized on paper, the protocol can be concretized as a realizable entity, such as a plan that inheres in a person. The objective specification is the part that says that some protein and DNA interactions are identified. This is a specification of a process endpoint: the boundary in the process before which they are not identified and after which they are. During the realization of the plan, the goal is to get to the point of having the interactions, and participants in the realization of the plan try to do that.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">Answers the question, why did you do this experiment?</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Barry Smith</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Bjoern Peters</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Jennifer Fostel</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">goal specification</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">OBI Plan and Planned Process/Roles Branch</obo:IAO_0000119>
         <obo:IAO_0000119 xml:lang="en">OBI_0000217</obo:IAO_0000119>
@@ -1101,12 +951,10 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000619">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000052"/>
-        <obo:IAO_0000111 xml:lang="en">consent textual entity</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">From Shiba et al. Acta Neuropathol Commun. 2013; 1: 45. (http://www.ncbi.nlm.nih.gov/pmc/articles/PMC3893467/):
 
 Written informed consent was obtained from the patient’s parents for publication of this Case report and any accompanying images. A copy of the written consent is available for review by the Editor-in chief of this journal.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A textual entity that documents the consenting process used to enroll patients in a study.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Bill Baumgartner</obo:IAO_0000117>
         <oboInOwl:hasExactSynonym>consent textual entity</oboInOwl:hasExactSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">consent/accessibility</rdfs:label>
     </owl:Class>
@@ -1137,7 +985,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>disorders</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>medical condition</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>other disease</oboInOwl:hasExactSynonym>
-        <oboInOwl:id>MONDO:0000001</oboInOwl:id>
         <rdfs:label>diseases</rdfs:label>
     </owl:Class>
     
@@ -1158,7 +1005,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>integumentary system disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of integument</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of integumental system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0002051</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">skin and subcutaneous tissue</rdfs:label>
     </owl:Class>
     
@@ -1178,7 +1024,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>musculoskeletal system disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of musculoskeletal system</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>musculoskeletal disorder</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0002081</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">musculoskeletal system</rdfs:label>
     </owl:Class>
     
@@ -1201,7 +1046,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>primary disorder of connective tissue</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>tissue disease, connective</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of connective tissue</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0003900</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">connective tissue</rdfs:label>
     </owl:Class>
     
@@ -1230,7 +1074,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>git disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>stomach or intestinal disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of digestive system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0004335</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">digestive system</rdfs:label>
     </owl:Class>
     
@@ -1255,7 +1098,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>organ system cancer</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>primary cancer</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>MT</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0004992</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">oncological</rdfs:label>
     </owl:Class>
     
@@ -1277,7 +1119,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>disorder of cardiovascular system</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>circulatory system disease</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of cardiovascular system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0004995</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circulatory system</rdfs:label>
     </owl:Class>
     
@@ -1299,7 +1140,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>neurological disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>neurological disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of nervous system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005071</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nervous system</rdfs:label>
     </owl:Class>
     
@@ -1315,7 +1155,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>mental or behavioural disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>mental process disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of mental process</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005084</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mental and behaviour disorders</rdfs:label>
     </owl:Class>
     
@@ -1335,7 +1174,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>respiratory system disease or disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>respiratory system disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of respiratory system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005087</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">respiratory system</rdfs:label>
     </owl:Class>
     
@@ -1357,7 +1195,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>endocrinopathy</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>thyroid or other glandular disorders</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of endocrine system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005151</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">endocrine/nutritional/metabolic disorders</rdfs:label>
     </owl:Class>
     
@@ -1378,7 +1215,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>infectious disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>transmissible disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disease by infectious agent</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005550</oboInOwl:id>
         <rdfs:comment>Replaces &apos;infection&apos; in disease hierarchy. OBI imported term infection is moved to pathologic process. This class is a container class for infectious diseases, not the process of infection itself.</rdfs:comment>
         <rdfs:label>infectious disease</rdfs:label>
     </owl:Class>
@@ -1410,10 +1246,8 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasRelatedSynonym>blood dyscrasia NOS</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of hematopoietic system</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>hematological disorders and malignancies</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0005570</oboInOwl:id>
         <rdfs:comment>placeholder for lymphoid disease</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">blood-related disorders</rdfs:label>
-        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/monarch-initiative/mondo/issues/254</rdfs:seeAlso>
     </owl:Class>
     
 
@@ -1427,7 +1261,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>trauma</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>traumatic injury</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>wound</oboInOwl:hasExactSynonym>
-        <oboInOwl:id>MONDO:0021178</oboInOwl:id>
         <rdfs:label>injury</rdfs:label>
     </owl:Class>
     
@@ -1445,7 +1278,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>visual system disease or disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>visual system disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of visual system</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0024458</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual system</rdfs:label>
     </owl:Class>
     
@@ -1479,7 +1311,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasRelatedSynonym>otolaryngological diseases</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>otorhinolaryngological disease</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>otorhinolaryngological diseases</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0024623</oboInOwl:id>
         <rdfs:comment>Editor note: consider uberon class</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases of the ear, nose, and/or throat</rdfs:label>
     </owl:Class>
@@ -1495,7 +1326,6 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasRelatedSynonym>Poisonings</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>intoxication</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>poisoning syndrome</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>MONDO:0029000</oboInOwl:id>
         <rdfs:label>poisoning</rdfs:label>
     </owl:Class>
     
@@ -1505,10 +1335,8 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000435">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000032"/>
-        <obo:IAO_0000111>genotyping assay</obo:IAO_0000111>
         <obo:IAO_0000112>High-throughput genotyping of oncogenic human papilloma viruses with MALDI-TOF mass spectrometry. Clin Chem. 2008 Jan;54(1):86-92. Epub 2007 Nov 2.PMID: 17981923</obo:IAO_0000112>
         <obo:IAO_0000115>An assay which generates data about a genotype from a specimen of genomic DNA. A variety of techniques and instruments can be used to produce information about sequence variation at particular genomic positions.</obo:IAO_0000115>
-        <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000118>SNP analysis</obo:IAO_0000118>
         <obo:IAO_0000118>genotype profiling</obo:IAO_0000118>
         <obo:IAO_0000119>OBI Biomaterial</obo:IAO_0000119>
@@ -1522,10 +1350,8 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000537">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000032"/>
-        <obo:IAO_0000111>copy number variation profiling assay</obo:IAO_0000111>
         <obo:IAO_0000112>Profiling of copy number variations (CNVs) in healthy individuals from three ethnic groups using a human genome 32 K BAC-clone-based array. PMID:18058796</obo:IAO_0000112>
         <obo:IAO_0000115>An assay that determines lost or amplified genomic regions of DNA by comparing genomic DNA originating from tissues from the same or different individuals using specific techniques such as CGH, array CGH, SNP genotyping</obo:IAO_0000115>
-        <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000118>CNV analysis</obo:IAO_0000118>
         <oboInOwl:hasExactSynonym>copy number variation profiling assay</oboInOwl:hasExactSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sequence variants (CNV, SNP arrays)</rdfs:label>
@@ -1537,9 +1363,7 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0001271">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000032"/>
-        <obo:IAO_0000111>RNA-seq assay</obo:IAO_0000111>
         <obo:IAO_0000115>An transcription profiling assay that determines an RNA sequence by analyzing the transcibed regions of the genome and or to quantitate transcript abundance.</obo:IAO_0000115>
-        <obo:IAO_0000117>James Malone</obo:IAO_0000117>
         <obo:IAO_0000118>transcription profiling by high throughput sequencing</obo:IAO_0000118>
         <obo:IAO_0000119>EFO:0002770</obo:IAO_0000119>
         <oboInOwl:hasExactSynonym>RNA-seq assay</oboInOwl:hasExactSynonym>
@@ -1552,10 +1376,7 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0001624">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000027"/>
-        <obo:IAO_0000111>organism identification assay</obo:IAO_0000111>
         <obo:IAO_0000115>An assay that identifies the organism species in a specimen.</obo:IAO_0000115>
-        <obo:IAO_0000117>Chris Stoeckert</obo:IAO_0000117>
-        <obo:IAO_0000117>Jie Zheng</obo:IAO_0000117>
         <obo:IAO_0000119>NIAID GSCID-BRC metadata working group</obo:IAO_0000119>
         <oboInOwl:hasExactSynonym>organism identification assay</oboInOwl:hasExactSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">microbiology</rdfs:label>
@@ -1567,10 +1388,7 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0002020">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000032"/>
-        <obo:IAO_0000111>epigenetic modification assay</obo:IAO_0000111>
         <obo:IAO_0000115>An assay that identifies epigenetic modifications including histone modifications, open chromatin, and DNA methylation.</obo:IAO_0000115>
-        <obo:IAO_0000117>Chris Stoeckert</obo:IAO_0000117>
-        <obo:IAO_0000117>Jie Zheng</obo:IAO_0000117>
         <obo:IAO_0000119>Penn group</obo:IAO_0000119>
         <oboInOwl:hasExactSynonym>epigenetic modification assay</oboInOwl:hasExactSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Epigenetics</rdfs:label>
@@ -1582,11 +1400,8 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0002117">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000032"/>
-        <obo:IAO_0000111>whole genome sequencing assay</obo:IAO_0000111>
         <obo:IAO_0000112>WGS permits comprehensive sequencing of introns and exons, whereas whole exome sequencing (WES) allows deeper sequencing of exonic regions at a lower cost. Due to the large number of genetic variants found in each genome, it is necessary to use filtering approaches to distinguish deleterious from benign variants. WES has been used successfully to identify novel genetic causes of primary immunodeficiency. Complex structural variations and non-Mendelian disorders remain challenges for WGS.</obo:IAO_0000112>
         <obo:IAO_0000115>A DNA sequencing assay that intends to provide information about the sequence of an entire genome of an organism.</obo:IAO_0000115>
-        <obo:IAO_0000116>Genotyping assays should ideally identify which part of the genome the information is about. We do not currently have a good way to do this. That information should be added later.</obo:IAO_0000116>
-        <obo:IAO_0000117>ImmPort</obo:IAO_0000117>
         <obo:IAO_0000118>WGS</obo:IAO_0000118>
         <obo:IAO_0000119>PMID:23095910</obo:IAO_0000119>
         <obo:IAO_0000119>PMID:25827230</obo:IAO_0000119>
@@ -1600,10 +1415,8 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0002118">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000032"/>
-        <obo:IAO_0000111>exome sequencing assay</obo:IAO_0000111>
         <obo:IAO_0000112>DNA was extracted from the Ficoll pellet of blood taken from congenital asplenia patients. Unamplified, high-molecular weight, RNase-treated genomic DNA (4_6 _g) was used for whole exome sequencing (WES) with the use of Agilent 71 Mb (V4 + UTR) singlesample capture and an Illumina HiSeq 2000. Sequencing was carried out so as to obtain 30_ coverage from 2 _ 100-bp paired-end reads. We used the Annovar tool (25) to annotate the resulting highquality (HQ) variants. In the regions targeted by WES capture (81.5% of the consensus coding genome), the mean numbers of single-nucleotide variants (SNVs) and small insertions/deletions (indels) detected per sample were 84,192 and13,325, respectively. After filtering, a mean of 74,398 (95.3%) high-quality (HQ) SNVs and 9,033 (70.6%) HQ indels were called. A mean of 105 coding HQ SNVs and 32 indels was identified.</obo:IAO_0000112>
         <obo:IAO_0000115>A DNA sequencing assay that intends to provide information about the sequence of the protein coding components of a genome (exons).</obo:IAO_0000115>
-        <obo:IAO_0000117>ImmPort</obo:IAO_0000117>
         <obo:IAO_0000118>WES</obo:IAO_0000118>
         <obo:IAO_0000119>PMID:25827230</obo:IAO_0000119>
         <oboInOwl:hasExactSynonym>exome sequencing assay</oboInOwl:hasExactSynonym>
@@ -1616,11 +1429,8 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0002415">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/EUPATH_0010032"/>
-        <obo:IAO_0000111>exposure to environmental and workplace carcinogens history</obo:IAO_0000111>
         <obo:IAO_0000115>A information content entity that indicates the exposure of an individual to carcinogens in the workplace or environment.</obo:IAO_0000115>
-        <obo:IAO_0000117>Chris Stoeckert, Helena Ellis</obo:IAO_0000117>
         <obo:IAO_0000119>OBIB</obo:IAO_0000119>
-        <obo:IAO_0000234>NCI BBRB</obo:IAO_0000234>
         <oboInOwl:hasExactSynonym>exposure to environmental and workplace carcinogens history</oboInOwl:hasExactSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposure to carcinogens</rdfs:label>
     </owl:Class>
@@ -1631,14 +1441,10 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0002623">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000032"/>
-        <obo:IAO_0000111>whole metagenome sequencing assay</obo:IAO_0000111>
         <obo:IAO_0000115>A DNA sequencing assay that intends to provide information on the DNA sequences of multiple genomes (a metagenome) from different organisms present in the same input sample.</obo:IAO_0000115>
-        <obo:IAO_0000116>Whole metagenome sequencing has been used to explore the composition and metabolic capability of communities of microbes found in the environment (e.g. in soil, water, etc.) and in humans and other species (e.g. in the gut, oral cavity, etc.).</obo:IAO_0000116>
-        <obo:IAO_0000117>Rebecca Jackson</obo:IAO_0000117>
         <obo:IAO_0000118>WMS</obo:IAO_0000118>
         <obo:IAO_0000119>Bjoern Peters</obo:IAO_0000119>
         <obo:IAO_0000119>Michelle Giglio</obo:IAO_0000119>
-        <obo:IAO_0000233>https://github.com/obi-ontology/obi/issues/1056</obo:IAO_0000233>
         <oboInOwl:hasExactSynonym>whole metagenome sequencing assay</oboInOwl:hasExactSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Metagenomics</rdfs:label>
     </owl:Class>
@@ -1649,13 +1455,9 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0500000">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000001"/>
-        <obo:IAO_0000111 xml:lang="en">study design</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">a matched pairs study design describes criteria by which subjects are identified as pairs which then undergo the same protocols, and the data generated is analyzed by comparing the differences between the paired subjects, which constitute the results of the executed study design.</obo:IAO_0000112>
         <obo:IAO_0000115>A plan specification comprised of protocols (which may specify how and what kinds of data will be gathered) that are executed as part of an investigation and is realized during a study design execution.</obo:IAO_0000115>
-        <obo:IAO_0000116>Editor note: there is at least an implicit restriction on the kind of data transformations that can be done based on the measured data available.</obo:IAO_0000116>
-        <obo:IAO_0000117>PERSON: Chris Stoeckert</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">experimental design</obo:IAO_0000118>
-        <obo:IAO_0000232 xml:lang="en">rediscussed at length (MC/JF/BP). 12/9/08). The definition was clarified to differentiate it from protocol.</obo:IAO_0000232>
         <oboInOwl:hasExactSynonym>study design</oboInOwl:hasExactSynonym>
         <rdfs:label>study design</rdfs:label>
     </owl:Class>
@@ -1666,10 +1468,8 @@ Written informed consent was obtained from the patient’s parents for publicati
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0500027">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000005"/>
-        <obo:IAO_0000111 xml:lang="en">inclusion criterion</obo:IAO_0000111>
         <obo:IAO_0000112 xml:lang="en">PMID: 23979341-The major inclusion criterion was patients in whom severe cerebral embolism was diagnosed at age 75 or younger (more than 9 in the NIHSS score on day 7 after the onset of stroke) .</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">an inclusion criterion (rule) is_a *eligibility criterion*  which defines and states a condition which, if met, makes an entity suitable for a given task or participation in a given process. For instance, in a study protocol, inclusion criteria indicate the conditions that prospective subjects MUST meet to be eligible for participation in a study.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Person: Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000118 xml:lang="en">inclusion condition</obo:IAO_0000118>
         <obo:IAO_0000118 xml:lang="en">inclusion rule</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">Adapted from Clinical Research Glossary Version 4.0 CDICS glossary group</obo:IAO_0000119>
@@ -1684,10 +1484,7 @@ Written informed consent was obtained from the patient’s parents for publicati
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OGMS_0000020">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000116"/>
         <obo:IAO_0000115 xml:lang="en">A process experienced by the patient, which can only be experienced by the patient, that is hypothesized to be clinically relevant.</obo:IAO_0000115>
-        <obo:IAO_0000116>note: defined class</obo:IAO_0000116>
         <obo:IAO_0000119>http://ontology.buffalo.edu/medo/Disease_and_Diagnosis.pdf</obo:IAO_0000119>
-        <obo:IAO_0000232>creation date: 2010-11-18T11:02:10Z
-Updated: 2020-07-06</obo:IAO_0000232>
         <oboInOwl:hasExactSynonym>symptom</oboInOwl:hasExactSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">signs and symptoms</rdfs:label>
     </owl:Class>
@@ -1709,8 +1506,6 @@ Updated: 2020-07-06</obo:IAO_0000232>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001995"/>
         <obo:IAO_0000115>A time quality inhering in a bearer by virtue of how long the bearer has existed.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>age</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>quality</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>PATO:0000011</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">age/birthdate</rdfs:label>
     </owl:Class>
     
@@ -1722,8 +1517,6 @@ Updated: 2020-07-06</obo:IAO_0000232>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001995"/>
         <obo:IAO_0000115>An organismal quality inhering in a bearer by virtue of the bearer&apos;s ability to undergo sexual reproduction in order to differentiate the individuals or types involved.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>biological sex</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>quality</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>PATO:0000047</oboInOwl:id>
         <rdfs:label>biological sex</rdfs:label>
     </owl:Class>
     
@@ -1735,8 +1528,6 @@ Updated: 2020-07-06</obo:IAO_0000232>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000056"/>
         <obo:IAO_0000115>A quality that inheres in an entire organism or part of an organism.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>organismal quality</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>quality</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>PATO:0001995</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">socio-demographic and economic characteristics</rdfs:label>
     </owl:Class>
     
@@ -1758,7 +1549,6 @@ Updated: 2020-07-06</obo:IAO_0000232>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PDRO_0010022">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000093"/>
-        <obo:IAO_0000111 xml:lang="en">prescribed drug administration specification</obo:IAO_0000111>
         <obo:IAO_0000112>&apos;take Aspirin 81 mg oral tablet, 1 tablet once daily by mouth, start today&apos; or the synonymous abbreviated version &apos;Aspirin 81 mg tablet PO DIE&apos;</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A drug administration description that specifies a drug administration prescribed or reported by an healthcare provider.
 
@@ -1778,9 +1568,6 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000093">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000052"/>
         <obo:IAO_0000115 xml:lang="en">Information about a calendar date or timestamp indicating day, month, year and time of an event.</obo:IAO_0000115>
-        <obo:IAO_0000117>Alejandra Gonzalez-Beltran</obo:IAO_0000117>
-        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
-        <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">STATO</obo:IAO_0000119>
         <oboInOwl:hasExactSynonym>date</oboInOwl:hasExactSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">date and time-related information</rdfs:label>
@@ -1793,14 +1580,9 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000105">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GECKO_0000116"/>
         <obo:IAO_0000115>A spatiotemporal region encompassing some part of the life cycle of an organism.</obo:IAO_0000115>
-        <obo:IAO_0000116>this class represents a proper part of the life cycle of an organism. The class &apos;life cycle&apos; should not be placed here</obo:IAO_0000116>
-        <obo:UBPROP_0000012>the WBls class &apos;all stages&apos; belongs here as it is the superclass of other WBls stages</obo:UBPROP_0000012>
-        <obo:UBPROP_0000012>we map the ZFS unknown stage here as it is logically equivalent to saying *some* life cycle stage</obo:UBPROP_0000012>
         <oboInOwl:hasExactSynonym>life cycle stage</oboInOwl:hasExactSynonym>
         <oboInOwl:hasNarrowSynonym>developmental stage</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasNarrowSynonym>stage</oboInOwl:hasNarrowSynonym>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>UBERON:0000105</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">life stage/time point</rdfs:label>
     </owl:Class>
     
@@ -1811,17 +1593,10 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000178">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000463"/>
         <obo:IAO_0000115>A fluid that is composed of blood plasma and erythrocytes.</obo:IAO_0000115>
-        <obo:IAO_0000232>This class excludes blood analogues, such as the insect analog of blood. See UBERON:0000179 haemolymphatic fluid.</obo:IAO_0000232>
-        <obo:UBPROP_0000001>A complex mixture of cells suspended in a liquid matrix that delivers nutrients to cells and removes wastes. (Source: BioGlossary, www.Biology-Text.com)[TAO]</obo:UBPROP_0000001>
-        <obo:UBPROP_0000001>Highly specialized circulating tissue consisting of several types of cells suspended in a fluid medium known as plasma.[AAO]</obo:UBPROP_0000001>
-        <obo:UBPROP_0000002>relationship loss: subclass specialized connective tissue (AAO:0000571)[AAO]</obo:UBPROP_0000002>
-        <obo:UBPROP_0000003>Recent findings strongly suggest that the molecular pathways involved in the development and function of blood cells are highly conserved among vertebrates and various invertebrates phyla. (...) There is now good reason to believe that, in vertebrates and invertebrates alike, blood cell lineages diverge from a common type of progenitor cell, the hemocytoblast.[well established][VHOG]</obo:UBPROP_0000003>
         <oboInOwl:hasExactSynonym>blood</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>portion of blood</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>vertebrate blood</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
         <oboInOwl:hasRelatedSynonym>whole blood</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>UBERON:0000178</oboInOwl:id>
         <rdfs:label>blood</rdfs:label>
     </owl:Class>
     
@@ -1837,8 +1612,6 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>organism substance</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>portion of body substance</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>portion of organism substance</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>UBERON:0000463</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sample type</rdfs:label>
     </owl:Class>
     
@@ -1849,10 +1622,7 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001088">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000463"/>
         <obo:IAO_0000115>Excretion that is the output of a kidney</obo:IAO_0000115>
-        <obo:UBPROP_0000008>kidney excreta from some taxa (e.g. in aves) may not be liquid</obo:UBPROP_0000008>
         <oboInOwl:hasExactSynonym>urine</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
-        <oboInOwl:id>UBERON:0001088</oboInOwl:id>
         <rdfs:label>urine</rdfs:label>
     </owl:Class>
     
@@ -1863,15 +1633,11 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001836">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000463"/>
         <obo:IAO_0000115>A fluid produced in the oral cavity by salivary glands, typically used in predigestion, but also in other functions.</obo:IAO_0000115>
-        <obo:UBPROP_0000007>salivary</obo:UBPROP_0000007>
-        <obo:UBPROP_0000008>We classify a wide variety of not necessarily homologous fluids here. In humans, the saliva is a turbid and slightly viscous fluid, generally of an alkaline reaction, and is secreted by the parotid, submaxillary, and sublingual glands. In the mouth the saliva is mixed with the secretion from the buccal glands. In man and many animals, saliva is an important digestive fluid on account of the presence of the peculiar enzyme, ptyalin</obo:UBPROP_0000008>
         <oboInOwl:hasExactSynonym>saliva</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>salivary gland secretion</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
         <oboInOwl:hasRelatedSynonym>sailva normalis</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>saliva atomaris</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>saliva molecularis</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>UBERON:0001836</oboInOwl:id>
         <rdfs:label>saliva</rdfs:label>
     </owl:Class>
     
@@ -1882,8 +1648,6 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001988">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000463"/>
         <obo:IAO_0000115>Portion of semisolid bodily waste discharged through the anus[MW,modified]</obo:IAO_0000115>
-        <obo:UBPROP_0000001>Excretion in semisolid state processed by the intestine.[FMA]</obo:UBPROP_0000001>
-        <obo:UBPROP_0000007>fecal</obo:UBPROP_0000007>
         <oboInOwl:hasBroadSynonym>excreta</oboInOwl:hasBroadSynonym>
         <oboInOwl:hasExactSynonym>faeces</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>fecal material</oboInOwl:hasExactSynonym>
@@ -1913,12 +1677,10 @@ It may also specify a starting drug administration condition</obo:IAO_0000115>
         <oboInOwl:hasNarrowSynonym>portion of scat</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasNarrowSynonym>scat</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasNarrowSynonym>spraint</oboInOwl:hasNarrowSynonym>
-        <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
         <oboInOwl:hasRelatedSynonym>droppings</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>excrement</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>ordure</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym>spoor</oboInOwl:hasRelatedSynonym>
-        <oboInOwl:id>UBERON:0001988</oboInOwl:id>
         <rdfs:label>stool</rdfs:label>
     </owl:Class>
 </rdf:RDF>


### PR DESCRIPTION
Previously, we included *all* annotations from import modules, but I think this brought in a lot of unnecessary data. The `gizmos.extract` module has been updated to handle subsets of annotations, so I think it would be good to utilize this feature.

This PR is a proposal to remove unnecessary annotation properties and **only include** the following from imports:

ID | Label
-- | --
IAO:0000112 | example of usage
IAO:0000115 | definition
IAO:0000118 | alternative term
IAO:0000119 | definition source
oboInOwl:hasAlternativeId | has_alternative_id
oboInOwl:hasBroadSynonym | has_broad_synonym
oboInOwl:hasExactSynonym | has_exact_synonym
oboInOwl:hasNarrowSynonym | has_narrow_synonym
oboInOwl:hasRelatedSynonym | has_related_synonym
rdfs:comment | comment
rdfs:label | label

The following are the annotation properties removed. I'm happy to add any of these back in if they are relevant.

ID | Label
-- | --
IAO:0000111 | editor preferred term
IAO:0000116 | editor note
IAO:0000117 | term editor
IAO:0000232 | curator note
IAO:0000233 | term tracker item
IAO:0000234 | ontology term requester
obo:UBPROP_0000001 | external_definition
obo:UBPROP_0000002 | axiom_lost_from_external_ontology
obo:UBPROP_0000003 | homology_notes
obo:UBPROP_0000007 | has_relational_adjective
obo:UBPROP_0000008 | taxon_notes
obo:UBPROP_0000012 | external_ontology_notes
oboInOwl:hasOBONamespace | has_obo_namespace
oboInOwl:id | id
oboInOwl:inSubset | in_subset
rdfs:seeAlso | see also


