### PR TITLE
Fix "connective tissue"

### DIFF
--- a/gecko.owl
+++ b/gecko.owl
@@ -11,7 +11,7 @@
      xmlns:terms="http://purl.org/dc/terms/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/gecko.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/gecko/releases/2020-11-27/gecko.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/gecko/releases/2020-12-03/gecko.owl"/>
         <dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An ontology to represent genomics cohort attributes.</dc:description>
         <dc:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Genomics Cohorts Knowledge Ontology</dc:title>
         <terms:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
@@ -1448,11 +1448,11 @@ Written informed consent was obtained from the patient’s parents for publicati
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MONDO_0003900">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MONDO_0000001"/>
         <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diseases</obo:GECKO_9000000>
-        <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">connective tissue</obo:GECKO_9000001>
+        <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">connective tissue diseases</obo:GECKO_9000001>
         <obo:IAO_0000115>A disease involving the connective tissue.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>connective tissue disease</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>connective tissue disease or disorder</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym>connective tissue diseases</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">connective tissue diseases</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>connective tissue disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>connective tissue disorders</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>disease of connective tissue</oboInOwl:hasExactSynonym>

--- a/src/ontology/templates/external.tsv
+++ b/src/ontology/templates/external.tsv
@@ -18,7 +18,7 @@ cause of participant death	cause of death	information content entity	other quest
 clinical history		information content entity		
 clinical measurement data item	physiological measurements	measurement datum	questionnaire/survey data	Replaces GECKO 'physiological measurements'
 collection of organisms		material entity		
-connective tissue disease	connective tissue	disease or disorder	diseases	
+connective tissue disease	connective tissue diseases	disease or disorder	diseases	
 consent textual entity	consent/accessibility	textual entity	survey administration	Replaces GECKO 'consent/accessibility'
 copy number variation profiling assay	Sequence variants (CNV, SNP arrays)	genomic assay	genomics	Replaces GECKO 'Sequence variants (CNV, SNP arrays)'
 count		measurement datum		

--- a/views/ihcc-gecko.csv
+++ b/views/ihcc-gecko.csv
@@ -101,7 +101,7 @@ cognitive and psychological measurements,GECKO:0000121,psychological distress an
 questionnaire/survey data,MONDO:0000001,diseases,A disease is a disposition to undergo pathological processes that exists in an organism because of one or more disorders in that organism.
 diseases,MONDO:0002051,skin and subcutaneous tissue,A disease involving the integumental system.
 diseases,MONDO:0002081,musculoskeletal system,A disease involving the musculoskeletal system.
-diseases,MONDO:0003900,connective tissue,A disease involving the connective tissue.
+diseases,MONDO:0003900,connective tissue diseases,A disease involving the connective tissue.
 diseases,MONDO:0004335,digestive system,A disease or disorder that involves the digestive system.
 diseases,MONDO:0004992,oncological,"A tumor composed of atypical neoplastic, often pleomorphic cells that invade other tissues. Malignant neoplasms often metastasize to distant anatomic sites and may recur after excision. The most common malignant neoplasms are carcinomas (adenocarcinomas or squamous cell carcinomas), Hodgkin and non-Hodgkin lymphomas, leukemias, melanomas, and sarcomas."
 diseases,MONDO:0004995,circulatory system,A disease involving the cardiovascular system.

--- a/views/ihcc-gecko.owl
+++ b/views/ihcc-gecko.owl
@@ -9,7 +9,7 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/gecko/ihcc-gecko.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/gecko/releases/2020-11-27/views/ihcc-gecko.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/gecko/releases/2020-12-03/views/ihcc-gecko.owl"/>
     </owl:Ontology>
     
 
@@ -1099,7 +1099,7 @@ Written informed consent was obtained from the patient’s parents for publicati
         <oboInOwl:hasExactSynonym>primary disorder of connective tissue</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>tissue disease, connective</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym>disorder of connective tissue</oboInOwl:hasRelatedSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">connective tissue</rdfs:label>
+        <rdfs:label>connective tissue diseases</rdfs:label>
     </owl:Class>
     
 


### PR DESCRIPTION
I missed "connective tissue disease" in the disease label update. This fixes the IHCC label from
> connective tissue

To
> connective tissue diseases