### PR TITLE
Add routine clinical visits

### DIFF
--- a/gecko.owl
+++ b/gecko.owl
@@ -387,6 +387,19 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0000305 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000305">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
+        <obo:GECKO_9000000 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">healthcare information</obo:GECKO_9000000>
+        <obo:GECKO_9000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">routine clincial visits</obo:GECKO_9000001>
+        <obo:IAO_0000115 xml:lang="en">a data item that is about an investigation and is the specified output of a data transformation that has only clinical visit data as input</obo:IAO_0000115>
+        <obo:IAO_0000119 xml:lang="en">EuPathDB</obo:IAO_0000119>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggregated clinical visit information</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/EUPATH_0000308 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000308">

--- a/src/ontology/annotations.owl
+++ b/src/ontology/annotations.owl
@@ -288,6 +288,15 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0000305 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000305">
+        <obo:IAO_0000115 xml:lang="en">a data item that is about an investigation and is the specified output of a data transformation that has only clinical visit data as input</obo:IAO_0000115>
+        <obo:IAO_0000119 xml:lang="en">EuPathDB</obo:IAO_0000119>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/EUPATH_0000308 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000308">

--- a/src/ontology/templates/external.tsv
+++ b/src/ontology/templates/external.tsv
@@ -1,6 +1,7 @@
 Label	IHCC Browser Label	Parent	Category	Comment
 LABEL	A 'IHCC browser label'	SC %	A 'IHCC category'	
 age	age/birthdate	quality	socio-demographic and economic characteristics	Replaces GECKO 'age/birthdate'
+aggregated clinical visit information	routine clincial visits	information content entity	healthcare information	
 assay		planned process		
 availability textual entity		textual entity		
 belief	personal beliefs and values	disposition	other questionnaire/survey data	

--- a/src/ontology/templates/index.tsv
+++ b/src/ontology/templates/index.tsv
@@ -15,6 +15,7 @@ CMO:0000021	body morphological measurement data item
 CMO:0000106	body height data item
 CMO:0000294	pulse data item
 EUPATH:0000147	cause of participant death
+EUPATH:0000305	aggregated clinical visit information
 EUPATH:0000308	hospitalization information
 EUPATH:0000359	occupation
 EUPATH:0000374	marital status

--- a/views/ihcc-gecko.csv
+++ b/views/ihcc-gecko.csv
@@ -50,6 +50,7 @@ physiological measurements,CMO:0000021,anthropometry,
 anthropometry,CMO:0000012,weight,
 anthropometry,CMO:0000106,height,
 questionnaire/survey data,EUPATH:0000451,healthcare information,An information content entity about healthcare that is private or public.
+healthcare information,EUPATH:0000305,routine clincial visits,a data item that is about an investigation and is the specified output of a data transformation that has only clinical visit data as input
 healthcare information,EUPATH:0000308,hospitalizations,an information content entity that is about a part of a health care encounter that occurs in a hospital facility
 healthcare information,GECKO:0000073,physician/practitioner info,"A textual entity that contains contact details for an individual's physician, which may include: name, phone number, address, etc."
 questionnaire/survey data,EUPATH:0010032,physical environment,environmental system associated with the dwelling used by humans.

--- a/views/ihcc-gecko.owl
+++ b/views/ihcc-gecko.owl
@@ -199,6 +199,18 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0000305 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000305">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/EUPATH_0000451"/>
+        <obo:IAO_0000115 xml:lang="en">a data item that is about an investigation and is the specified output of a data transformation that has only clinical visit data as input</obo:IAO_0000115>
+        <obo:IAO_0000119 xml:lang="en">EuPathDB</obo:IAO_0000119>
+        <oboInOwl:hasExactSynonym>aggregated clinical visit information</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">routine clincial visits</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/EUPATH_0000308 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000308">


### PR DESCRIPTION
Resolves #42 

I used [EUPATH:0000305](https://www.ebi.ac.uk/ols/ontologies/eupath/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FEUPATH_0000305) - "aggregated clinical visit information". We were already using EUPATH for hospitalization information, so I think it makes sense to stick with that. The IHCC browser label is "routine clinical visits".

@mcourtot please let me know if you think this makes sense to add! 