### PR TITLE
gizmos 0.1.1 -> 0.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ontodev-gizmos==0.1.1
+ontodev-gizmos==0.1.4


### PR DESCRIPTION
Fix for make fail with following error message because of old gizmos dependency

```
python3 -m gizmos.extract -d build/imports/bfo.db -T build/imports/bfo.txt -P build/annotations.txt -n > build/imports/bfo.ttl
usage: extract.py [-h] -d DATABASE [-t TERM] [-T TERMS] [-a ANNOTATION]
                  [-A ANNOTATIONS] [-n]
extract.py: error: unrecognized arguments: -P build/annotations.txt
```
